### PR TITLE
Add WAV loading and parser tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/agents_tareas
+++ b/agents_tareas
@@ -1,6 +1,6 @@
 1. [x] Configurar la estructura base del proyecto web (HTML, CSS, JS) y mostrar un canvas de 720px de alto junto a los menús superior e inferior sin funcionalidades.
 2. [x] Implementar botón “Cargar MIDI/XML” y lógica básica para leer archivos MIDI/XML extrayendo note ON/OFF, duración, velocidad, tempo y nombres de pista.
-3. Implementar botón “Cargar WAV” y reproducción de audio, eliminando silencios iniciales y sincronizando el playhead con la animación.
+3. [x] Implementar botón “Cargar WAV” y reproducción de audio, eliminando silencios iniciales y sincronizando el playhead con la animación.
 4. Crear estructura de datos que relacione cada pista con su instrumento y familia, asignando formas y colores predeterminados.
 5. Dibujar notas básicas en el canvas desplazándose de derecha a izquierda, alineadas con NOTE ON/OFF y la línea de presente al centro.
 6. Incorporar opacidad variable en los extremos, cambio brusco al 100% en la línea de presente y retorno progresivo al 5%.
@@ -10,4 +10,4 @@
 10. Añadir opciones de aspecto 16:9 y 9:16, con soporte para pantalla completa y supermuestreo.
 11. Implementar menú inferior con dropdowns de Instrumento y Familia siempre visibles, y panel desplegable para personalizar color y figura por familia.
 12. Optimizar rendimiento y modularizar el código con comentarios claros para facilitar el desarrollo incremental.
-13. Implementar pruebas unitarias básicas para las funciones de parseo de archivos MIDI y MusicXML.
+13. [x] Implementar pruebas unitarias básicas para las funciones de parseo de archivos MIDI y MusicXML.

--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
 <body>
   <nav id="top-menu">
     <button id="load-midi">Cargar MIDI/XML</button>
-    <button>Cargar WAV</button>
-    <button>Play/Stop</button>
+    <button id="load-wav">Cargar WAV</button>
+    <button id="play-stop">Play/Stop</button>
     <button>Adelantar</button>
     <button>Atrasar</button>
     <button>Inicio</button>
@@ -25,6 +25,13 @@
     type="file"
     id="midi-file-input"
     accept=".mid,.midi,.xml"
+    style="display: none"
+  />
+
+  <input
+    type="file"
+    id="wav-file-input"
+    accept=".wav,audio/wav"
     style="display: none"
   />
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "visualizadormidi",
+  "version": "1.0.0",
+  "description": "",
+  "main": "script.js",
+  "scripts": {
+    "test": "node test_parsers.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/test_parsers.js
+++ b/test_parsers.js
@@ -1,0 +1,70 @@
+const assert = require('assert');
+const { parseMIDI, parseMusicXML } = require('./script.js');
+
+// Prueba para parseMIDI con un archivo mínimo en memoria
+function testParseMIDI() {
+  const header = [
+    0x4d, 0x54, 0x68, 0x64, // 'MThd'
+    0x00, 0x00, 0x00, 0x06, // length
+    0x00, 0x00, // format 0
+    0x00, 0x01, // one track
+    0x00, 0x60, // division
+  ];
+  const trackEvents = [
+    0x00, 0xff, 0x03, 0x04, 0x74, 0x65, 0x73, 0x74, // track name 'test'
+    0x00, 0x90, 0x3c, 0x40, // note on C4
+    0x60, 0x80, 0x3c, 0x40, // note off after 96 ticks
+    0x00, 0xff, 0x2f, 0x00, // end of track
+  ];
+  const trackLength = trackEvents.length;
+  const trackHeader = [
+    0x4d, 0x54, 0x72, 0x6b,
+    (trackLength >> 24) & 0xff,
+    (trackLength >> 16) & 0xff,
+    (trackLength >> 8) & 0xff,
+    trackLength & 0xff,
+  ];
+  const bytes = new Uint8Array([...header, ...trackHeader, ...trackEvents]);
+  const midi = parseMIDI(bytes.buffer);
+  assert.strictEqual(midi.tracks.length, 1);
+  assert.strictEqual(midi.tracks[0].name, 'test');
+  const note = midi.tracks[0].events.find((e) => e.type === 'note');
+  assert(note);
+  assert.strictEqual(note.noteNumber, 60);
+  assert.strictEqual(note.duration, 96);
+  console.log('parseMIDI OK');
+}
+
+// Prueba básica para parseMusicXML
+function testParseMusicXML() {
+  const xml = `
+    <score-partwise version="3.1">
+      <part-list>
+        <score-part id="P1">
+          <part-name>Piano</part-name>
+        </score-part>
+      </part-list>
+      <part id="P1">
+        <measure number="1">
+          <attributes>
+            <divisions>1</divisions>
+          </attributes>
+          <note>
+            <pitch>
+              <step>C</step>
+              <octave>4</octave>
+            </pitch>
+            <duration>1</duration>
+          </note>
+        </measure>
+      </part>
+    </score-partwise>`;
+  const result = parseMusicXML(xml);
+  assert.strictEqual(result.tracks.length, 1);
+  const note = result.tracks[0].events[0];
+  assert.strictEqual(note.noteNumber, 60);
+  console.log('parseMusicXML OK');
+}
+
+testParseMIDI();
+testParseMusicXML();


### PR DESCRIPTION
## Summary
- enable loading WAV files with audio playback and initial silence trimming
- add Node-compatible MusicXML parser and unit tests for MIDI/MusicXML parsing
- mark corresponding incremental tasks as completed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a993b115548333ae03120b0eaaa179