### PR TITLE
Add mapping of tracks to instruments and families

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -1,7 +1,7 @@
 1. [x] Configurar la estructura base del proyecto web (HTML, CSS, JS) y mostrar un canvas de 720px de alto junto a los menús superior e inferior sin funcionalidades.
 2. [x] Implementar botón “Cargar MIDI/XML” y lógica básica para leer archivos MIDI/XML extrayendo note ON/OFF, duración, velocidad, tempo y nombres de pista.
 3. [x] Implementar botón “Cargar WAV” y reproducción de audio, eliminando silencios iniciales y sincronizando el playhead con la animación.
-4. Crear estructura de datos que relacione cada pista con su instrumento y familia, asignando formas y colores predeterminados.
+4. [x] Crear estructura de datos que relacione cada pista con su instrumento y familia, asignando formas y colores predeterminados.
 5. Dibujar notas básicas en el canvas desplazándose de derecha a izquierda, alineadas con NOTE ON/OFF y la línea de presente al centro.
 6. Incorporar opacidad variable en los extremos, cambio brusco al 100% en la línea de presente y retorno progresivo al 5%.
 7. Añadir efectos de “bump” y “brillo” en el NOTE ON presente.
@@ -11,3 +11,4 @@
 11. Implementar menú inferior con dropdowns de Instrumento y Familia siempre visibles, y panel desplegable para personalizar color y figura por familia.
 12. Optimizar rendimiento y modularizar el código con comentarios claros para facilitar el desarrollo incremental.
 13. [x] Implementar pruebas unitarias básicas para las funciones de parseo de archivos MIDI y MusicXML.
+14. Integrar la estructura de pistas con el menú inferior, poblando dinámicamente el dropdown de instrumentos según los archivos cargados.

--- a/script.js
+++ b/script.js
@@ -91,6 +91,51 @@ if (typeof document !== 'undefined') {
 
 // ----- Parsing helpers -----
 
+// Datos de familias con formas y colores predeterminados
+const FAMILY_PRESETS = {
+  'Maderas de timbre "redondo"': { shape: 'oval', color: '#0000ff' },
+  'Dobles cañas': { shape: 'star', color: '#8a2be2' },
+  'Saxofones': { shape: 'star', color: '#a0522d' },
+  Metales: { shape: 'capsule', color: '#ffff00' },
+  'Percusión menor': { shape: 'pentagon', color: '#808080' },
+  Tambores: { shape: 'circle', color: '#808080' },
+  Platillos: { shape: 'circle', color: '#808080' },
+  Placas: { shape: 'square', color: '#ff0000' },
+  Auxiliares: { shape: 'circle', color: '#4b0082' },
+  'Cuerdas frotadas': { shape: 'triangle', color: '#ffa500' },
+  'Cuerdas pulsadas': { shape: 'star4', color: '#008000' },
+  Voces: { shape: 'capsule', color: '#808080' },
+};
+
+// Relación simple de instrumentos con familias
+const INSTRUMENT_FAMILIES = {
+  Flauta: 'Maderas de timbre "redondo"',
+  Oboe: 'Dobles cañas',
+  Clarinete: 'Dobles cañas',
+  Fagot: 'Dobles cañas',
+  Saxofón: 'Saxofones',
+  Trompeta: 'Metales',
+  Trombón: 'Metales',
+  Tuba: 'Metales',
+  'Corno francés': 'Metales',
+  Piano: 'Cuerdas pulsadas',
+  Violín: 'Cuerdas frotadas',
+  Viola: 'Cuerdas frotadas',
+  Violonchelo: 'Cuerdas frotadas',
+  Contrabajo: 'Cuerdas frotadas',
+  Voz: 'Voces',
+};
+
+// Asigna instrumento, familia, forma y color a cada pista
+function assignTrackInfo(tracks) {
+  return tracks.map((t) => {
+    const instrument = t.name;
+    const family = INSTRUMENT_FAMILIES[instrument] || 'Desconocida';
+    const preset = FAMILY_PRESETS[family] || { shape: 'unknown', color: '#ffffff' };
+    return { ...t, instrument, family, shape: preset.shape, color: preset.color };
+  });
+}
+
 function parseMIDI(arrayBuffer) {
   const data = new DataView(arrayBuffer);
   let offset = 0;
@@ -199,6 +244,7 @@ function parseMIDI(arrayBuffer) {
     result.tracks.push({ name: trackName, events });
   }
 
+  result.tracks = assignTrackInfo(result.tracks);
   return result;
 }
 
@@ -226,7 +272,8 @@ function parseMusicXML(text) {
       }
       currentTime += duration;
     }
-    return { tempo, divisions, tracks: [{ name: trackName, events }] };
+    const tracks = assignTrackInfo([{ name: trackName, events }]);
+    return { tempo, divisions, tracks };
   }
 
   const parser = new DOMParser();
@@ -266,9 +313,15 @@ function parseMusicXML(text) {
     return { name: trackName, events };
   });
 
-  return { tempo, divisions, tracks };
+  return { tempo, divisions, tracks: assignTrackInfo(tracks) };
 }
 
 if (typeof module !== 'undefined') {
-  module.exports = { parseMIDI, parseMusicXML };
+  module.exports = {
+    parseMIDI,
+    parseMusicXML,
+    assignTrackInfo,
+    FAMILY_PRESETS,
+    INSTRUMENT_FAMILIES,
+  };
 }

--- a/test_parsers.js
+++ b/test_parsers.js
@@ -1,5 +1,9 @@
 const assert = require('assert');
-const { parseMIDI, parseMusicXML } = require('./script.js');
+const {
+  parseMIDI,
+  parseMusicXML,
+  assignTrackInfo,
+} = require('./script.js');
 
 // Prueba para parseMIDI con un archivo mínimo en memoria
 function testParseMIDI() {
@@ -66,5 +70,21 @@ function testParseMusicXML() {
   console.log('parseMusicXML OK');
 }
 
+// Prueba para asignación de familia e instrumentación
+function testAssignTrackInfo() {
+  const tracks = [
+    { name: 'Flauta', events: [] },
+    { name: 'Desconocido', events: [] },
+  ];
+  const enriched = assignTrackInfo(tracks);
+  const flute = enriched.find((t) => t.name === 'Flauta');
+  assert.strictEqual(flute.family, 'Maderas de timbre "redondo"');
+  assert.strictEqual(flute.shape, 'oval');
+  const unknown = enriched.find((t) => t.name === 'Desconocido');
+  assert.strictEqual(unknown.family, 'Desconocida');
+  console.log('assignTrackInfo OK');
+}
+
 testParseMIDI();
 testParseMusicXML();
+testAssignTrackInfo();


### PR DESCRIPTION
## Summary
- add family presets and instrument-family mapping
- expose assignTrackInfo to enrich parsed tracks
- test family assignment and update tasks list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9951692a88333902d77e5bba1d06d