### PR TITLE
Populate instrument dropdown from parsed tracks

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -11,4 +11,6 @@
 11. Implementar menú inferior con dropdowns de Instrumento y Familia siempre visibles, y panel desplegable para personalizar color y figura por familia.
 12. Optimizar rendimiento y modularizar el código con comentarios claros para facilitar el desarrollo incremental.
 13. [x] Implementar pruebas unitarias básicas para las funciones de parseo de archivos MIDI y MusicXML.
-14. Integrar la estructura de pistas con el menú inferior, poblando dinámicamente el dropdown de instrumentos según los archivos cargados.
+14. [x] Integrar la estructura de pistas con el menú inferior, poblando dinámicamente el dropdown de instrumentos según los archivos cargados.
+15. Renderizar rectángulos estáticos en el canvas representando notas basadas en eventos (subtarea de la 5).
+16. Animar las notas desplazándose de derecha a izquierda sincronizadas con el tiempo.

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
       <option>Cuerdas frotadas</option>
       <option>Cuerdas pulsadas</option>
       <option>Voces</option>
+      <option>Desconocida</option>
     </select>
   </nav>
 

--- a/script.js
+++ b/script.js
@@ -15,6 +15,25 @@ if (typeof document !== 'undefined') {
     const loadWavBtn = document.getElementById('load-wav');
     const wavInput = document.getElementById('wav-file-input');
     const playBtn = document.getElementById('play-stop');
+    const instrumentSelect = document.getElementById('instrument-select');
+    const familySelect = document.getElementById('family-select');
+    let currentTracks = [];
+
+    function populateInstrumentDropdown(tracks) {
+      instrumentSelect.innerHTML = '<option>Instrumento</option>';
+      tracks.forEach((t) => {
+        const opt = document.createElement('option');
+        opt.value = t.instrument;
+        opt.textContent = t.instrument;
+        instrumentSelect.appendChild(opt);
+      });
+    }
+
+    instrumentSelect.addEventListener('change', () => {
+      const selected = instrumentSelect.value;
+      const track = currentTracks.find((t) => t.instrument === selected);
+      familySelect.value = track ? track.family : '';
+    });
 
     // ----- Configuración de Audio -----
     const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -36,12 +55,16 @@ if (typeof document !== 'undefined') {
       if (ext === 'mid' || ext === 'midi') {
         reader.onload = (ev) => {
           const midi = parseMIDI(ev.target.result);
+          currentTracks = midi.tracks;
+          populateInstrumentDropdown(currentTracks);
           console.log('MIDI parsed', midi);
         };
         reader.readAsArrayBuffer(file);
       } else if (ext === 'xml') {
         reader.onload = (ev) => {
           const xml = parseMusicXML(ev.target.result);
+          currentTracks = xml.tracks;
+          populateInstrumentDropdown(currentTracks);
           console.log('MusicXML parsed', xml);
         };
         reader.readAsText(file);


### PR DESCRIPTION
## Summary
- Dynamically list instruments from parsed MIDI or MusicXML files.
- Sync selected instrument with its family and include a fallback "Desconocida" option.
- Extend task plan with steps for rendering and animating notes.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a99606e558833390d9a2562b138381