### PR TITLE
Add drag-and-drop instrument family assignment modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,9 +53,24 @@
       <option>Cuerdas frotadas</option>
       <option>Cuerdas pulsadas</option>
       <option>Voces</option>
-      <option>Desconocida</option>
     </select>
   </nav>
+
+  <div id="assignment-modal" class="hidden">
+    <div class="modal-content">
+      <div class="modal-columns">
+        <div class="instruments-column">
+          <h3>Instrumentos</h3>
+          <ul id="modal-instrument-list"></ul>
+        </div>
+        <div class="families-column">
+          <h3>Familias</h3>
+          <div id="modal-family-zones"></div>
+        </div>
+      </div>
+      <button id="apply-assignments">Aplicar</button>
+    </div>
+  </div>
 
   <script src="script.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -20,3 +20,64 @@ body {
   border: 1px solid #444;
   height: 720px;
 }
+
+#assignment-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: none;
+  align-items: center;
+  justify-content: center;
+}
+
+#assignment-modal .modal-content {
+  background: #222;
+  padding: 20px;
+  max-width: 800px;
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.modal-columns {
+  display: flex;
+  gap: 20px;
+}
+
+.instruments-column,
+.families-column {
+  flex: 1;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+#modal-instrument-list,
+.family-zone ul {
+  list-style: none;
+  padding: 0;
+}
+
+.instrument-item {
+  padding: 5px;
+  margin: 2px 0;
+  background: #333;
+  cursor: grab;
+}
+
+.family-zone {
+  border: 1px dashed #555;
+  padding: 5px;
+  margin-bottom: 10px;
+}
+
+.family-zone h4 {
+  margin: 0 0 5px;
+}
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- add modal with drag-and-drop to assign instruments to families on MIDI load
- remember instrument-family selections and sync lower menus
- remove "Desconocida" option from family menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a99802d31c8333966e0fd5a0d48ad7