### PR TITLE
Add visual effects unit tests

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -14,5 +14,6 @@
 14. [x] Integrar la estructura de pistas con el menú inferior, poblando dinámicamente el dropdown de instrumentos según los archivos cargados.
 15. [x] Renderizar rectángulos estáticos en el canvas representando notas basadas en eventos (subtarea de la 5).
 16. [x] Animar las notas desplazándose de derecha a izquierda sincronizadas con el tiempo.
-17. Crear pruebas unitarias para la lógica de opacidad y efectos visuales.
+17. [x] Crear pruebas unitarias para la lógica de opacidad y efectos visuales.
 18. Crear pruebas unitarias para los controles de reproducción.
+19. Crear pruebas unitarias para el efecto de brillo en el NOTE ON.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-    "test": "node test_parsers.js"
+    "test": "node test_parsers.js && node test_visual_effects.js"
   },
   "keywords": [],
   "author": "",

--- a/test_visual_effects.js
+++ b/test_visual_effects.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const { computeOpacity, computeBumpHeight } = require('./script');
+
+function approx(actual, expected, eps = 1e-6) {
+  assert(Math.abs(actual - expected) < eps, `${actual} != ${expected}`);
+}
+
+// Pruebas para computeOpacity
+approx(computeOpacity(250, 350, 600), 1); // Nota cruzando el centro
+approx(computeOpacity(-50, 50, 600), 0.05); // Nota lejos del centro
+approx(computeOpacity(125, 175, 600), 0.375); // Nota a mitad de distancia
+
+// Pruebas para computeBumpHeight
+const base = 10;
+approx(computeBumpHeight(base, -0.1, 0, 1), base); // Antes de la nota
+approx(computeBumpHeight(base, 0, 0, 1), 15); // En el NOTE ON
+approx(computeBumpHeight(base, 0.5, 0, 1), 12.5); // Mitad del intervalo
+approx(computeBumpHeight(base, 1, 0, 1), base); // En el NOTE OFF
+
+console.log('Pruebas de efectos visuales completadas');


### PR DESCRIPTION
## Summary
- extract computeOpacity and computeBumpHeight helpers and export them
- add unit tests for opacity falloff and bump height effects
- document progress in agents_tareas and run tests in package.json

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9a1d535408333962e564d6e19ac0c