### PR TITLE
Add playback controls unit tests

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -15,5 +15,7 @@
 15. [x] Renderizar rectángulos estáticos en el canvas representando notas basadas en eventos (subtarea de la 5).
 16. [x] Animar las notas desplazándose de derecha a izquierda sincronizadas con el tiempo.
 17. [x] Crear pruebas unitarias para la lógica de opacidad y efectos visuales.
-18. Crear pruebas unitarias para los controles de reproducción.
+18. [x] Crear pruebas unitarias para los controles de reproducción.
 19. Crear pruebas unitarias para el efecto de brillo en el NOTE ON.
+20. Implementar figuras geométricas alargadas para cada familia.
+21. Aplicar variaciones de tono de color por instrumento dentro de cada familia.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-    "test": "node test_parsers.js && node test_visual_effects.js"
+    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js"
   },
   "keywords": [],
   "author": "",

--- a/script.js
+++ b/script.js
@@ -20,6 +20,17 @@ function computeBumpHeight(baseHeight, currentSec, start, end) {
   return baseHeight * (1.5 - 0.5 * clamped);
 }
 
+// Calcula un nuevo offset al buscar hacia adelante o atrás
+function computeSeekOffset(startOffset, delta, duration, trimOffset = 0) {
+  const maxOffset = Math.max(0, duration - trimOffset);
+  return Math.min(Math.max(0, startOffset + delta), maxOffset);
+}
+
+// Reinicia el offset de reproducción al inicio
+function resetStartOffset() {
+  return 0;
+}
+
 if (typeof document !== 'undefined') {
   document.addEventListener('DOMContentLoaded', () => {
     const canvas = document.getElementById('visualizer');
@@ -235,8 +246,7 @@ if (typeof document !== 'undefined') {
       if (!audioBuffer) return;
       const wasPlaying = isPlaying;
       stopPlayback(true);
-      const maxOffset = Math.max(0, audioBuffer.duration - trimOffset);
-      startOffset = Math.min(Math.max(0, startOffset + delta), maxOffset);
+      startOffset = computeSeekOffset(startOffset, delta, audioBuffer.duration, trimOffset);
       renderFrame(startOffset);
       if (wasPlaying) startPlayback();
     }
@@ -323,8 +333,8 @@ if (typeof document !== 'undefined') {
     restartBtn.addEventListener('click', () => {
       const wasPlaying = isPlaying;
       stopPlayback(false);
-      startOffset = 0;
-      renderFrame(0);
+      startOffset = resetStartOffset();
+      renderFrame(startOffset);
       if (wasPlaying) startPlayback();
     });
     document.addEventListener('keydown', (e) => {
@@ -670,5 +680,7 @@ if (typeof module !== 'undefined') {
     INSTRUMENT_FAMILIES,
     computeOpacity,
     computeBumpHeight,
+    computeSeekOffset,
+    resetStartOffset,
   };
 }

--- a/test_playback_controls.js
+++ b/test_playback_controls.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const { computeSeekOffset, resetStartOffset } = require('./script');
+
+// Pruebas para computeSeekOffset
+assert.strictEqual(computeSeekOffset(0, 3, 10, 0), 3); // adelantar dentro del rango
+assert.strictEqual(computeSeekOffset(0, -3, 10, 0), 0); // no retrocede por debajo de 0
+assert.strictEqual(computeSeekOffset(8, 5, 10, 0), 10); // límite superior sin trim
+assert.strictEqual(computeSeekOffset(5, 5, 10, 2), 8); // límite considerando trim
+
+// Prueba para resetStartOffset
+assert.strictEqual(resetStartOffset(), 0);
+
+console.log('Pruebas de controles de reproducción completadas');
+


### PR DESCRIPTION
## Summary
- expose helpers to compute seek offsets and reset playback state
- test playback seek and reset logic
- update test script and task list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9a2f38af88333a3a2bd31bf59f425