### PR TITLE
Add glow alpha calculation with tests

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -16,6 +16,8 @@
 16. [x] Animar las notas desplazándose de derecha a izquierda sincronizadas con el tiempo.
 17. [x] Crear pruebas unitarias para la lógica de opacidad y efectos visuales.
 18. [x] Crear pruebas unitarias para los controles de reproducción.
-19. Crear pruebas unitarias para el efecto de brillo en el NOTE ON.
+19. [x] Crear pruebas unitarias para el efecto de brillo en el NOTE ON.
 20. Implementar figuras geométricas alargadas para cada familia.
 21. Aplicar variaciones de tono de color por instrumento dentro de cada familia.
+22. Crear pruebas unitarias para las figuras geométricas alargadas.
+23. Crear pruebas unitarias para las variaciones de tono de color por instrumento.

--- a/script.js
+++ b/script.js
@@ -20,6 +20,13 @@ function computeBumpHeight(baseHeight, currentSec, start, end) {
   return baseHeight * (1.5 - 0.5 * clamped);
 }
 
+// Calcula la intensidad del brillo en el NOTE ON
+function computeGlowAlpha(currentSec, start, glowDuration = 0.2) {
+  if (currentSec < start || currentSec > start + glowDuration) return 0;
+  const progress = (currentSec - start) / glowDuration;
+  return 1 - progress;
+}
+
 // Calcula un nuevo offset al buscar hacia adelante o atrás
 function computeSeekOffset(startOffset, delta, duration, trimOffset = 0) {
   const maxOffset = Math.max(0, duration - trimOffset);
@@ -390,10 +397,10 @@ if (typeof document !== 'undefined') {
         ctx.restore();
 
         // Brillo blanco corto en el NOTE ON presente
-        if (currentSec >= n.start && currentSec <= n.start + 0.2) {
-          const glowProgress = 1 - (currentSec - n.start) / 0.2;
+        const glowAlpha = computeGlowAlpha(currentSec, n.start);
+        if (glowAlpha > 0) {
           ctx.save();
-          ctx.globalAlpha = glowProgress;
+          ctx.globalAlpha = glowAlpha;
           ctx.strokeStyle = '#fff';
           ctx.lineWidth = 2;
           ctx.strokeRect(xStart, y, width, height);
@@ -680,6 +687,7 @@ if (typeof module !== 'undefined') {
     INSTRUMENT_FAMILIES,
     computeOpacity,
     computeBumpHeight,
+    computeGlowAlpha,
     computeSeekOffset,
     resetStartOffset,
   };

--- a/test_visual_effects.js
+++ b/test_visual_effects.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { computeOpacity, computeBumpHeight } = require('./script');
+const { computeOpacity, computeBumpHeight, computeGlowAlpha } = require('./script');
 
 function approx(actual, expected, eps = 1e-6) {
   assert(Math.abs(actual - expected) < eps, `${actual} != ${expected}`);
@@ -16,5 +16,10 @@ approx(computeBumpHeight(base, -0.1, 0, 1), base); // Antes de la nota
 approx(computeBumpHeight(base, 0, 0, 1), 15); // En el NOTE ON
 approx(computeBumpHeight(base, 0.5, 0, 1), 12.5); // Mitad del intervalo
 approx(computeBumpHeight(base, 1, 0, 1), base); // En el NOTE OFF
+
+// Pruebas para computeGlowAlpha
+approx(computeGlowAlpha(0, 0), 1); // Inicio del brillo
+approx(computeGlowAlpha(0.1, 0), 0.5); // Mitad del efecto
+approx(computeGlowAlpha(0.25, 0), 0); // Efecto terminado
 
 console.log('Pruebas de efectos visuales completadas');


### PR DESCRIPTION
## Summary
- expose `computeGlowAlpha` helper for NOTE ON brightness effect
- reuse `computeGlowAlpha` during rendering to draw glow outlines
- add unit tests for the glow calculation and update task list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9a4085e408333971fc77deb2570b4