### PR TITLE
feat: vary colors by instrument

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -18,6 +18,6 @@
 18. [x] Crear pruebas unitarias para los controles de reproducción.
 19. [x] Crear pruebas unitarias para el efecto de brillo en el NOTE ON.
 20. Implementar figuras geométricas alargadas para cada familia.
-21. Aplicar variaciones de tono de color por instrumento dentro de cada familia.
+21. [x] Aplicar variaciones de tono de color por instrumento dentro de cada familia.
 22. Crear pruebas unitarias para las figuras geométricas alargadas.
-23. Crear pruebas unitarias para las variaciones de tono de color por instrumento.
+23. [x] Crear pruebas unitarias para las variaciones de tono de color por instrumento.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js"
+    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js"
   },
   "keywords": [],
   "author": "",

--- a/test_color_variations.js
+++ b/test_color_variations.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const {
+  assignTrackInfo,
+  FAMILY_PRESETS,
+  INSTRUMENT_COLOR_SHIFT,
+  adjustColorBrightness,
+} = require('./script.js');
+
+// Verifica oscurecimiento para instrumentos más graves
+const clarinetTrack = assignTrackInfo([{ name: 'Clarinete', events: [] }])[0];
+const clarinetBase = FAMILY_PRESETS['Dobles cañas'].color;
+const clarinetExpected = adjustColorBrightness(
+  clarinetBase,
+  INSTRUMENT_COLOR_SHIFT['Clarinete']
+);
+assert.strictEqual(clarinetTrack.color, clarinetExpected);
+
+// Verifica aclarado para instrumentos más agudos
+const trumpetTrack = assignTrackInfo([{ name: 'Trompeta', events: [] }])[0];
+const trumpetBase = FAMILY_PRESETS['Metales'].color;
+const trumpetExpected = adjustColorBrightness(
+  trumpetBase,
+  INSTRUMENT_COLOR_SHIFT['Trompeta']
+);
+assert.strictEqual(trumpetTrack.color, trumpetExpected);
+
+console.log('Pruebas de variaciones de color por instrumento completadas');


### PR DESCRIPTION
## Summary
- adjust note color brightness based on instrument register
- verify color shifts for clarinet and trumpet

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9a4fb498483338fc64343fe72f046