### PR TITLE
Implementar figuras geométricas por familia y pruebas de dibujo

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -5,7 +5,7 @@
 5. [x] Dibujar notas básicas en el canvas desplazándose de derecha a izquierda, alineadas con NOTE ON/OFF y la línea de presente al centro.
 6. [x] Incorporar opacidad variable en los extremos, cambio brusco al 100% en la línea de presente y retorno progresivo al 5%.
 7. [x] Añadir efectos de “bump” y “brillo” en el NOTE ON presente.
-8. Implementar figuras geométricas correspondientes a cada familia y variaciones de tono por instrumento.
+8. [x] Implementar figuras geométricas correspondientes a cada familia.
 9. [x] Agregar controles de reproducción: Play/Stop (barra espaciadora), Adelantar, Atrasar e Inicio.
 10. Añadir opciones de aspecto 16:9 y 9:16, con soporte para pantalla completa y supermuestreo.
 11. Implementar menú inferior con dropdowns de Instrumento y Familia siempre visibles, y panel desplegable para personalizar color y figura por familia.
@@ -17,7 +17,8 @@
 17. [x] Crear pruebas unitarias para la lógica de opacidad y efectos visuales.
 18. [x] Crear pruebas unitarias para los controles de reproducción.
 19. [x] Crear pruebas unitarias para el efecto de brillo en el NOTE ON.
-20. Implementar figuras geométricas alargadas para cada familia.
+20. [x] Implementar figuras geométricas alargadas para cada familia.
 21. [x] Aplicar variaciones de tono de color por instrumento dentro de cada familia.
-22. Crear pruebas unitarias para las figuras geométricas alargadas.
+22. [x] Crear pruebas unitarias para las figuras geométricas alargadas.
 23. [x] Crear pruebas unitarias para las variaciones de tono de color por instrumento.
+24. Ajustar representación de figuras no alargadas y tamaños especiales por familia (platillos +30%, auxiliares +30% bump, etc.).

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js"
+    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js"
   },
   "keywords": [],
   "author": "",

--- a/script.js
+++ b/script.js
@@ -27,6 +27,87 @@ function computeGlowAlpha(currentSec, start, glowDuration = 0.2) {
   return 1 - progress;
 }
 
+// Dibuja una figura en el contexto del canvas según el tipo especificado
+function drawNoteShape(ctx, shape, x, y, width, height, stroke = false) {
+  ctx.beginPath();
+  switch (shape) {
+    case 'oval':
+      ctx.ellipse(x + width / 2, y + height / 2, width / 2, height / 2, 0, 0, Math.PI * 2);
+      break;
+    case 'capsule': {
+      const r = height / 2;
+      ctx.moveTo(x + r, y);
+      ctx.lineTo(x + width - r, y);
+      ctx.arc(x + width - r, y + r, r, -Math.PI / 2, Math.PI / 2);
+      ctx.lineTo(x + r, y + height);
+      ctx.arc(x + r, y + r, r, Math.PI / 2, -Math.PI / 2, true);
+      break;
+    }
+    case 'star': {
+      const cx = x + width / 2;
+      const cy = y + height / 2;
+      const w = width / 2;
+      const h = height / 2;
+      ctx.moveTo(cx, y);
+      ctx.lineTo(cx + w * 0.2, cy - h * 0.2);
+      ctx.lineTo(x + width, cy);
+      ctx.lineTo(cx + w * 0.2, cy + h * 0.2);
+      ctx.lineTo(cx, y + height);
+      ctx.lineTo(cx - w * 0.2, cy + h * 0.2);
+      ctx.lineTo(x, cy);
+      ctx.lineTo(cx - w * 0.2, cy - h * 0.2);
+      ctx.closePath();
+      break;
+    }
+    case 'triangle':
+      ctx.moveTo(x, y);
+      ctx.lineTo(x + width, y + height / 2);
+      ctx.lineTo(x, y + height);
+      ctx.closePath();
+      break;
+    case 'circle':
+      ctx.arc(x + width / 2, y + height / 2, height / 2, 0, Math.PI * 2);
+      break;
+    case 'square':
+      ctx.rect(x, y, width, height);
+      break;
+    case 'star4': {
+      const cx = x + width / 2;
+      const cy = y + height / 2;
+      const w = width / 2;
+      const h = height / 2;
+      ctx.moveTo(cx, y);
+      ctx.lineTo(cx + w * 0.3, cy);
+      ctx.lineTo(x + width, cy);
+      ctx.lineTo(cx, cy + h * 0.3);
+      ctx.lineTo(cx, y + height);
+      ctx.lineTo(cx - w * 0.3, cy);
+      ctx.lineTo(x, cy);
+      ctx.lineTo(cx, cy - h * 0.3);
+      ctx.closePath();
+      break;
+    }
+    case 'pentagon': {
+      const cx = x + width / 2;
+      const cy = y + height / 2;
+      const r = Math.min(width, height) / 2;
+      for (let i = 0; i < 5; i++) {
+        const angle = (-Math.PI / 2) + (i * (2 * Math.PI) / 5);
+        const px = cx + r * Math.cos(angle);
+        const py = cy + r * Math.sin(angle);
+        if (i === 0) ctx.moveTo(px, py);
+        else ctx.lineTo(px, py);
+      }
+      ctx.closePath();
+      break;
+    }
+    default:
+      ctx.rect(x, y, width, height);
+  }
+  if (stroke) ctx.stroke();
+  else ctx.fill();
+}
+
 // Ajusta el brillo de un color hex según un factor (-1 a 1)
 function adjustColorBrightness(color, factor) {
   const r = parseInt(color.slice(1, 3), 16);
@@ -383,6 +464,7 @@ if (typeof document !== 'undefined') {
               end: start + duration,
               noteNumber: ev.noteNumber,
               color: track.color || '#ffffff',
+              shape: track.shape || 'square',
             });
           }
         });
@@ -413,7 +495,7 @@ if (typeof document !== 'undefined') {
         ctx.save();
         ctx.globalAlpha = alpha;
         ctx.fillStyle = n.color;
-        ctx.fillRect(xStart, y, width, height);
+        drawNoteShape(ctx, n.shape, xStart, y, width, height);
         ctx.restore();
 
         // Brillo blanco corto en el NOTE ON presente
@@ -423,7 +505,7 @@ if (typeof document !== 'undefined') {
           ctx.globalAlpha = glowAlpha;
           ctx.strokeStyle = '#fff';
           ctx.lineWidth = 2;
-          ctx.strokeRect(xStart, y, width, height);
+          drawNoteShape(ctx, n.shape, xStart, y, width, height, true);
           ctx.restore();
         }
       });
@@ -733,5 +815,6 @@ if (typeof module !== 'undefined') {
     computeGlowAlpha,
     computeSeekOffset,
     resetStartOffset,
+    drawNoteShape,
   };
 }

--- a/test_shapes.js
+++ b/test_shapes.js
@@ -1,0 +1,62 @@
+const assert = require('assert');
+const { drawNoteShape } = require('./script.js');
+
+function stubCtx() {
+  const ctx = {
+    beginPathCalled: false,
+    ellipseCalled: false,
+    arcCalled: false,
+    rectCalled: false,
+    lineToCalled: false,
+    moveToCalled: false,
+    strokeCalled: false,
+    fillCalled: false,
+  };
+  ctx.beginPath = () => {
+    ctx.beginPathCalled = true;
+  };
+  ctx.ellipse = () => {
+    ctx.ellipseCalled = true;
+  };
+  ctx.arc = () => {
+    ctx.arcCalled = true;
+  };
+  ctx.rect = () => {
+    ctx.rectCalled = true;
+  };
+  ctx.lineTo = () => {
+    ctx.lineToCalled = true;
+  };
+  ctx.moveTo = () => {
+    ctx.moveToCalled = true;
+  };
+  ctx.closePath = () => {};
+  ctx.fill = () => {
+    ctx.fillCalled = true;
+  };
+  ctx.stroke = () => {
+    ctx.strokeCalled = true;
+  };
+  return ctx;
+}
+
+const shapes = [
+  ['oval', 'ellipseCalled'],
+  ['capsule', 'arcCalled'],
+  ['circle', 'arcCalled'],
+  ['square', 'rectCalled'],
+  ['triangle', 'lineToCalled'],
+  ['star', 'lineToCalled'],
+  ['star4', 'lineToCalled'],
+  ['pentagon', 'lineToCalled'],
+];
+
+shapes.forEach(([shape, expected]) => {
+  const ctx = stubCtx();
+  drawNoteShape(ctx, shape, 0, 0, 10, 10);
+  assert(ctx[expected], `esperado ${expected} para ${shape}`);
+  assert(ctx.beginPathCalled, 'beginPath no llamado');
+  assert(ctx.fillCalled, 'fill no llamado');
+});
+
+console.log('Pruebas de figuras geométricas completadas');


### PR DESCRIPTION
## Resumen
- Añadida función `drawNoteShape` para renderizar distintas figuras según la familia del instrumento.
- Notas ahora guardan la figura asignada y `renderFrame` utiliza esta función para dibujar y aplicar brillo.
- Se agregaron pruebas unitarias para verificar la llamada adecuada de cada figura y se integraron al flujo de `npm test`.
- Se actualizaron las tareas para reflejar el progreso y se añadió una nueva tarea de mejora de figuras.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9a6356cf88333bef910f5443d45c4