### PR TITLE
Adjust non-stretched shapes and family modifiers

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -21,4 +21,5 @@
 21. [x] Aplicar variaciones de tono de color por instrumento dentro de cada familia.
 22. [x] Crear pruebas unitarias para las figuras geométricas alargadas.
 23. [x] Crear pruebas unitarias para las variaciones de tono de color por instrumento.
-24. Ajustar representación de figuras no alargadas y tamaños especiales por familia (platillos +30%, auxiliares +30% bump, etc.).
+24. [x] Ajustar representación de figuras no alargadas y tamaños especiales por familia (platillos +30%, auxiliares +30% bump, etc.).
+25. [x] Crear pruebas unitarias para los modificadores de familia.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js"
+      "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js"
   },
   "keywords": [],
   "author": "",

--- a/test_family_modifiers.js
+++ b/test_family_modifiers.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const { getFamilyModifiers, computeNoteWidth } = require('./script');
+
+// Modificadores de familia
+const platillos = getFamilyModifiers('Platillos');
+assert.strictEqual(platillos.sizeFactor, 1.3);
+assert.strictEqual(platillos.bump, 0.5);
+
+const auxiliares = getFamilyModifiers('Auxiliares');
+assert.strictEqual(auxiliares.bump, 0.8);
+
+const defaultMods = getFamilyModifiers('Desconocida');
+assert.strictEqual(defaultMods.sizeFactor, 1);
+
+// Cálculo del ancho para figuras no alargadas
+const notePlatillos = { start: 0, end: 1, shape: 'circle', family: 'Platillos' };
+assert.strictEqual(computeNoteWidth(notePlatillos, 10, 20), 13);
+
+const noteTambores = { start: 0, end: 1, shape: 'circle', family: 'Tambores' };
+assert.strictEqual(computeNoteWidth(noteTambores, 10, 20), 10);
+
+console.log('Pruebas de modificadores de familia completadas');

--- a/test_visual_effects.js
+++ b/test_visual_effects.js
@@ -16,6 +16,7 @@ approx(computeBumpHeight(base, -0.1, 0, 1), base); // Antes de la nota
 approx(computeBumpHeight(base, 0, 0, 1), 15); // En el NOTE ON
 approx(computeBumpHeight(base, 0.5, 0, 1), 12.5); // Mitad del intervalo
 approx(computeBumpHeight(base, 1, 0, 1), base); // En el NOTE OFF
+approx(computeBumpHeight(base, 0, 0, 1, 0.8), 18); // Bump +30%
 
 // Pruebas para computeGlowAlpha
 approx(computeGlowAlpha(0, 0), 1); // Inicio del brillo


### PR DESCRIPTION
## Summary
- Add family modifiers controlling size and bump for note rendering
- Support non-stretched shapes like circles and squares with special cases for Platillos and Auxiliares
- Extend visual effect tests and introduce family modifier tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9a7ca3c98833387e983faee40fc35