### PR TITLE
feat: reset family customizations

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -24,4 +24,5 @@
 24. [x] Ajustar representación de figuras no alargadas y tamaños especiales por familia (platillos +30%, auxiliares +30% bump, etc.).
 25. [x] Crear pruebas unitarias para los modificadores de familia.
 26. [x] Crear pruebas unitarias para la lógica de cambio de aspecto y pantalla completa.
-27. Permitir restablecer los colores y figuras personalizados de las familias a los valores predeterminados.
+27. [x] Permitir restablecer los colores y figuras personalizados de las familias a los valores predeterminados.
+28. Permitir exportar e importar la configuración de familias e instrumentos en archivos JSON.

--- a/script.js
+++ b/script.js
@@ -306,6 +306,15 @@ if (typeof document !== 'undefined') {
         item.appendChild(shapeSelect);
         familyPanel.appendChild(item);
       });
+
+      const resetBtn = document.createElement('button');
+      resetBtn.id = 'reset-family-defaults';
+      resetBtn.textContent = 'Restablecer predeterminados';
+      resetBtn.addEventListener('click', () => {
+        resetFamilyCustomizations(currentTracks);
+        buildFamilyPanel();
+      });
+      familyPanel.appendChild(resetBtn);
     }
 
     function populateInstrumentDropdown(tracks) {
@@ -708,7 +717,7 @@ if (typeof document !== 'undefined') {
 // ----- Parsing helpers -----
 
 // Datos de familias con formas y colores predeterminados
-const FAMILY_PRESETS = {
+const FAMILY_DEFAULTS = {
   'Maderas de timbre "redondo"': { shape: 'oval', color: '#0000ff' },
   'Dobles cañas': { shape: 'star', color: '#8a2be2' },
   'Saxofones': { shape: 'star', color: '#a0522d' },
@@ -722,6 +731,9 @@ const FAMILY_PRESETS = {
   'Cuerdas pulsadas': { shape: 'star4', color: '#008000' },
   Voces: { shape: 'capsule', color: '#808080' },
 };
+
+// Copia mutable de los valores predeterminados
+const FAMILY_PRESETS = JSON.parse(JSON.stringify(FAMILY_DEFAULTS));
 
 // Relación simple de instrumentos con familias
 const INSTRUMENT_FAMILIES = {
@@ -811,6 +823,22 @@ function setFamilyCustomization(family, { color, shape }, tracks = []) {
       const shift = INSTRUMENT_COLOR_SHIFT[t.instrument] || 0;
       t.color = adjustColorBrightness(preset.color, shift);
     }
+  });
+}
+
+function resetFamilyCustomizations(tracks = []) {
+  Object.keys(FAMILY_DEFAULTS).forEach((fam) => {
+    FAMILY_PRESETS[fam] = { ...FAMILY_DEFAULTS[fam] };
+  });
+  familyCustomizations = {};
+  if (typeof localStorage !== 'undefined') {
+    localStorage.removeItem('familyCustomizations');
+  }
+  tracks.forEach((t) => {
+    const preset = FAMILY_PRESETS[t.family] || { shape: 'square', color: '#ffffff' };
+    t.shape = preset.shape;
+    const shift = INSTRUMENT_COLOR_SHIFT[t.instrument] || 0;
+    t.color = adjustColorBrightness(preset.color, shift);
   });
 }
 
@@ -1012,6 +1040,7 @@ if (typeof module !== 'undefined') {
     parseMusicXML,
     assignTrackInfo,
     FAMILY_PRESETS,
+    FAMILY_DEFAULTS,
     INSTRUMENT_FAMILIES,
     INSTRUMENT_COLOR_SHIFT,
     adjustColorBrightness,
@@ -1026,5 +1055,6 @@ if (typeof module !== 'undefined') {
     calculateCanvasSize,
     NON_STRETCHED_SHAPES,
     setFamilyCustomization,
+    resetFamilyCustomizations,
   };
 }

--- a/test_family_customization.js
+++ b/test_family_customization.js
@@ -5,6 +5,8 @@ const {
   FAMILY_PRESETS,
   INSTRUMENT_COLOR_SHIFT,
   adjustColorBrightness,
+  resetFamilyCustomizations,
+  FAMILY_DEFAULTS,
 } = require('./script.js');
 
 const tracks = assignTrackInfo([{ name: 'Flauta', events: [] }]);
@@ -28,5 +30,22 @@ const expectedColor = adjustColorBrightness(
 );
 assert.strictEqual(tracks[0].color, expectedColor);
 assert.strictEqual(tracks[0].shape, 'square');
+
+resetFamilyCustomizations(tracks);
+
+assert.strictEqual(
+  FAMILY_PRESETS['Maderas de timbre "redondo"'].color,
+  FAMILY_DEFAULTS['Maderas de timbre "redondo"'].color
+);
+assert.strictEqual(
+  FAMILY_PRESETS['Maderas de timbre "redondo"'].shape,
+  FAMILY_DEFAULTS['Maderas de timbre "redondo"'].shape
+);
+const expectedResetColor = adjustColorBrightness(
+  FAMILY_DEFAULTS['Maderas de timbre "redondo"'].color,
+  INSTRUMENT_COLOR_SHIFT['Flauta']
+);
+assert.strictEqual(tracks[0].color, expectedResetColor);
+assert.strictEqual(tracks[0].shape, FAMILY_DEFAULTS['Maderas de timbre "redondo"'].shape);
 
 console.log('Pruebas de personalización de familias completadas');


### PR DESCRIPTION
## Summary
- allow resetting family shape and color customizations to defaults
- add tests and UI button for resetting
- track task completion for resetting feature and plan export/import presets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9b0bbd2bc8333af520595782bb565