### PR TITLE
Add configuration export/import for families and instruments

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -25,4 +25,5 @@
 25. [x] Crear pruebas unitarias para los modificadores de familia.
 26. [x] Crear pruebas unitarias para la lógica de cambio de aspecto y pantalla completa.
 27. [x] Permitir restablecer los colores y figuras personalizados de las familias a los valores predeterminados.
-28. Permitir exportar e importar la configuración de familias e instrumentos en archivos JSON.
+28. [x] Permitir exportar e importar la configuración de familias e instrumentos en archivos JSON.
+29. [x] Crear pruebas unitarias para la exportación e importación de configuraciones.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-      "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js"
+      "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js"
   },
   "keywords": [],
   "author": "",

--- a/test_config_export_import.js
+++ b/test_config_export_import.js
@@ -1,0 +1,30 @@
+const assert = require('assert');
+const {
+  assignTrackInfo,
+  exportConfiguration,
+  importConfiguration,
+  INSTRUMENT_COLOR_SHIFT,
+  adjustColorBrightness,
+} = require('./script.js');
+
+const tracks = assignTrackInfo([{ name: 'Flauta', events: [] }]);
+
+const config = {
+  assignedFamilies: { Flauta: 'Metales' },
+  familyCustomizations: { Metales: { color: '#123456', shape: 'triangle' } },
+};
+
+importConfiguration(config, tracks);
+
+assert.strictEqual(tracks[0].family, 'Metales');
+assert.strictEqual(tracks[0].shape, 'triangle');
+const expectedColor = adjustColorBrightness(
+  '#123456',
+  INSTRUMENT_COLOR_SHIFT['Flauta']
+);
+assert.strictEqual(tracks[0].color, expectedColor);
+
+const exported = JSON.parse(exportConfiguration());
+assert.deepStrictEqual(exported, config);
+
+console.log('Pruebas de exportación e importación completadas');


### PR DESCRIPTION
## Summary
- allow exporting and importing instrument/family configuration as JSON
- add UI buttons for exporting and importing config in family panel
- cover configuration import/export with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9b202597c83339ec4d1e5ffed862c