### PR TITLE
fix: avoid global redeclaration of utility functions

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -4,6 +4,7 @@
  * la modularidad y facilitar su reutilización en pruebas.
  */
 
+(function (global) {
 // Cache simple para evitar recalcular ajustes de color
 const colorCache = new Map();
 
@@ -227,9 +228,10 @@ const utils = {
   resetStartOffset,
 };
 
-if (typeof module !== 'undefined') {
+if (typeof module !== 'undefined' && module.exports) {
   module.exports = utils;
 } else {
-  window.utils = utils;
+  global.utils = utils;
 }
+})(typeof globalThis !== 'undefined' ? globalThis : this);
 


### PR DESCRIPTION
## Summary
- wrap `utils.js` in an IIFE and use a safe global reference to prevent global function collisions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9b51d8d9883338d862d4de2cacf05