### PR TITLE
Refactor UI into module and add integration test

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -27,5 +27,6 @@
 27. [x] Permitir restablecer los colores y figuras personalizados de las familias a los valores predeterminados.
 28. [x] Permitir exportar e importar la configuración de familias e instrumentos en archivos JSON.
 29. [x] Crear pruebas unitarias para la exportación e importación de configuraciones.
-30. Refactorizar la lógica de la interfaz en módulos separados y crear pruebas de integración básicas.
+30. [x] Refactorizar la lógica de la interfaz en módulos separados y crear pruebas de integración básicas.
 31. Optimizar el renderizado de notas utilizando técnicas de canvas offscreen.
+32. Modularizar la lógica de carga de archivos MIDI y WAV en componentes separados.

--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-      "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js"
+    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "jsdom": "^23.0.0"
+  }
 }

--- a/test_ui_integration.js
+++ b/test_ui_integration.js
@@ -1,0 +1,50 @@
+const assert = require('assert');
+const { JSDOM } = require('jsdom');
+const { initializeUI } = require('./ui');
+
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+<button id="play-stop"></button>
+<button id="seek-forward"></button>
+<button id="seek-backward"></button>
+<button id="restart"></button>
+<button id="aspect-16-9"></button>
+<button id="aspect-9-16"></button>
+<button id="full-screen"></button>
+</body></html>`);
+
+global.document = dom.window.document;
+
+let playing = false;
+let playCalls = 0;
+let stopCalls = 0;
+let forwardCalls = 0;
+
+initializeUI({
+  isPlaying: () => playing,
+  onPlay: () => {
+    playing = true;
+    playCalls++;
+  },
+  onStop: () => {
+    playing = false;
+    stopCalls++;
+  },
+  onForward: () => {
+    forwardCalls++;
+  },
+  onBackward: () => {},
+  onRestart: () => {},
+  onAspect169: () => {},
+  onAspect916: () => {},
+  onFullScreen: () => {},
+});
+
+document.getElementById('play-stop').click();
+document.getElementById('play-stop').click();
+document.getElementById('seek-forward').click();
+
+assert.strictEqual(playCalls, 1);
+assert.strictEqual(stopCalls, 1);
+assert.strictEqual(forwardCalls, 1);
+
+console.log('Pruebas de integración de UI completadas');

--- a/ui.js
+++ b/ui.js
@@ -1,0 +1,53 @@
+/**
+ * Module to initialize UI controls for playback and layout.
+ */
+function initializeUI({
+  isPlaying,
+  onPlay,
+  onStop,
+  onForward,
+  onBackward,
+  onRestart,
+  onAspect169,
+  onAspect916,
+  onFullScreen,
+}) {
+  const playBtn = document.getElementById('play-stop');
+  const forwardBtn = document.getElementById('seek-forward');
+  const backwardBtn = document.getElementById('seek-backward');
+  const restartBtn = document.getElementById('restart');
+  const aspect169Btn = document.getElementById('aspect-16-9');
+  const aspect916Btn = document.getElementById('aspect-9-16');
+  const fullScreenBtn = document.getElementById('full-screen');
+
+  playBtn.addEventListener('click', () => {
+    if (isPlaying()) {
+      onStop();
+    } else {
+      onPlay();
+    }
+  });
+
+  forwardBtn.addEventListener('click', () => onForward());
+  backwardBtn.addEventListener('click', () => onBackward());
+  restartBtn.addEventListener('click', () => onRestart());
+  aspect169Btn.addEventListener('click', () => onAspect169());
+  aspect916Btn.addEventListener('click', () => onAspect916());
+  fullScreenBtn.addEventListener('click', () => onFullScreen());
+
+  return {
+    playBtn,
+    forwardBtn,
+    backwardBtn,
+    restartBtn,
+    aspect169Btn,
+    aspect916Btn,
+    fullScreenBtn,
+  };
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { initializeUI };
+} else {
+  window.ui = { initializeUI };
+}


### PR DESCRIPTION
## Summary
- extract UI control wiring into `ui.js` module
- refactor main script to use `initializeUI`
- add integration test using jsdom and update task list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9b64a7ed8833384b3904ffee13178