### PR TITLE
fix: load ui module before main script

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
   </div>
 
   <script src="utils.js"></script>
+  <script src="ui.js"></script>
   <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include ui.js before main script to ensure initializeUI is defined and prevent TypeError

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9b77707088333bb73082bcd1b69e3