### PR TITLE
fix: avoid initializeUI redeclaration

### DIFF
--- a/script.js
+++ b/script.js
@@ -17,7 +17,10 @@ const {
   resetStartOffset,
 } = typeof require !== 'undefined' ? require('./utils.js') : window.utils;
 
-const { initializeUI } =
+// "initializeUI" se declara globalmente en ui.js cuando se carga en el navegador.
+// Para evitar un error de "Identifier has already been declared" al importar
+// la función en este archivo, renombramos la referencia local.
+const { initializeUI: initializeUIControls } =
   typeof require !== 'undefined' ? require('./ui.js') : window.ui;
 
 if (typeof document !== 'undefined') {
@@ -419,7 +422,7 @@ if (typeof document !== 'undefined') {
     });
 
     // Reproducción básica Play/Stop con animación y controles de búsqueda
-    const uiControls = initializeUI({
+    const uiControls = initializeUIControls({
       isPlaying: () => isPlaying,
       onPlay: async () => {
         if (!audioBuffer) return;


### PR DESCRIPTION
## Summary
- rename local import to avoid `initializeUI` redeclaration error
- update usage to call `initializeUIControls`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9b875ba2c833386e6c7b0ede8a486