### PR TITLE
Optimize note rendering using offscreen canvas

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -28,5 +28,6 @@
 28. [x] Permitir exportar e importar la configuración de familias e instrumentos en archivos JSON.
 29. [x] Crear pruebas unitarias para la exportación e importación de configuraciones.
 30. [x] Refactorizar la lógica de la interfaz en módulos separados y crear pruebas de integración básicas.
-31. Optimizar el renderizado de notas utilizando técnicas de canvas offscreen.
+31. [x] Optimizar el renderizado de notas utilizando técnicas de canvas offscreen.
 32. Modularizar la lógica de carga de archivos MIDI y WAV en componentes separados.
+33. Crear pruebas unitarias para el renderizado mediante canvas offscreen.


### PR DESCRIPTION
## Summary
- Buffer note drawing in an offscreen canvas and blit to main canvas each frame for smoother rendering
- Resize offscreen canvas alongside main canvas when aspect ratio or fullscreen changes
- Mark offscreen rendering task as complete and track follow-up tests in agents_tareas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9ba26953c8333b9b8f13a0841c639