### PR TITLE
Hide present line and extend task list

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -33,3 +33,12 @@
 33. Crear pruebas unitarias para el renderizado mediante canvas offscreen.
 34. Modularizar la lógica de reproducción de audio en un componente separado.
 35. Crear pruebas unitarias para la lógica modular de reproducción de audio.
+36. [ ] El color de fondo del canvas debe ser negro absoluto, pero en el panel inferior debe existir la posibilidad de cambiar el color del canvas.
+37. [x] La línea de presente debe ser invisible.
+38. [ ] Las cápsulas deben ser rectángulos con esquinas redondeadas.
+39. [ ] El botón de play debe funcionar así esté cargado solo el MIDI/XML sin audio, o el audio sin MIDI/XML.
+40. [ ] La animación debe estar en 60 fps fijos SIEMPRE, y no depender de la frecuencia de la pantalla.
+41. [ ] La velocidad del midi debe salir del tempo map, y NO ser una velocidad constante.
+42. [ ] El brillo de las figuras al pasar por la línea de presente debe ser de tipo glow/blur, y parecer una sombra más que una línea definida.
+43. [ ] Los triángulos deben ser equiláteros con el ángulo superior al medio de la figura.
+44. [ ] En algún menú debe existir la posibilidad de activar o desactivar instrumentos para incluirlos o eliminarlos de la animación.

--- a/script.js
+++ b/script.js
@@ -519,11 +519,7 @@ if (typeof document !== 'undefined') {
           offscreenCtx.restore();
         }
       });
-      offscreenCtx.strokeStyle = '#fff';
-      offscreenCtx.beginPath();
-      offscreenCtx.moveTo(canvas.width / 2, 0);
-      offscreenCtx.lineTo(canvas.width / 2, canvas.height);
-      offscreenCtx.stroke();
+      // Línea de presente omitida para mantenerla invisible
 
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       ctx.drawImage(offscreenCanvas, 0, 0);


### PR DESCRIPTION
## Summary
- Add new development tasks and mark the present-line item as completed
- Remove present line drawing so timeline indicator stays invisible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9bf18403c8333894911739967c224