### PR TITLE
feat: allow canvas background customization

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -33,12 +33,13 @@
 33. Crear pruebas unitarias para el renderizado mediante canvas offscreen.
 34. Modularizar la lógica de reproducción de audio en un componente separado.
 35. Crear pruebas unitarias para la lógica modular de reproducción de audio.
-36. [ ] El color de fondo del canvas debe ser negro absoluto, pero en el panel inferior debe existir la posibilidad de cambiar el color del canvas.
+36. [x] El color de fondo del canvas debe ser negro absoluto, pero en el panel inferior debe existir la posibilidad de cambiar el color del canvas.
 37. [x] La línea de presente debe ser invisible.
-38. [ ] Las cápsulas deben ser rectángulos con esquinas redondeadas.
+38. [x] Las cápsulas deben ser rectángulos con esquinas redondeadas.
 39. [ ] El botón de play debe funcionar así esté cargado solo el MIDI/XML sin audio, o el audio sin MIDI/XML.
 40. [ ] La animación debe estar en 60 fps fijos SIEMPRE, y no depender de la frecuencia de la pantalla.
 41. [ ] La velocidad del midi debe salir del tempo map, y NO ser una velocidad constante.
 42. [ ] El brillo de las figuras al pasar por la línea de presente debe ser de tipo glow/blur, y parecer una sombra más que una línea definida.
 43. [ ] Los triángulos deben ser equiláteros con el ángulo superior al medio de la figura.
 44. [ ] En algún menú debe existir la posibilidad de activar o desactivar instrumentos para incluirlos o eliminarlos de la animación.
+45. [x] Crear pruebas unitarias para la personalización del color del canvas.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js"
+    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js"
   },
   "keywords": [],
   "author": "",

--- a/script.js
+++ b/script.js
@@ -38,9 +38,10 @@ if (typeof document !== 'undefined') {
     offscreenCanvas.width = canvas.width;
     offscreenCanvas.height = canvas.height;
 
-    // Relleno inicial del canvas como marcador de posición usando el canvas offscreen
-    offscreenCtx.fillStyle = '#222';
+    // Relleno inicial del canvas en negro absoluto
+    offscreenCtx.fillStyle = '#000000';
     offscreenCtx.fillRect(0, 0, offscreenCanvas.width, offscreenCanvas.height);
+    canvas.style.backgroundColor = '#000000';
     ctx.drawImage(offscreenCanvas, 0, 0);
 
     const loadBtn = document.getElementById('load-midi');
@@ -94,6 +95,35 @@ if (typeof document !== 'undefined') {
 
     function buildFamilyPanel() {
       familyPanel.innerHTML = '';
+
+      const bgItem = document.createElement('div');
+      bgItem.className = 'family-config-item';
+      const bgLabel = document.createElement('label');
+      bgLabel.textContent = 'Color del canvas';
+      const bgInput = document.createElement('input');
+      bgInput.type = 'color';
+      bgInput.id = 'canvas-color-input';
+      const toHex = (val) => {
+        if (!val) return '#000000';
+        if (val.startsWith('#')) return val;
+        const m = val.match(/\d+/g);
+        if (!m) return '#000000';
+        return `#${m
+          .slice(0, 3)
+          .map((n) => parseInt(n, 10).toString(16).padStart(2, '0'))
+          .join('')}`;
+      };
+      bgInput.value = toHex(canvas.style.backgroundColor);
+      bgInput.addEventListener('change', () => {
+        canvas.style.backgroundColor = bgInput.value;
+        offscreenCtx.fillStyle = bgInput.value;
+        offscreenCtx.fillRect(0, 0, offscreenCanvas.width, offscreenCanvas.height);
+        ctx.drawImage(offscreenCanvas, 0, 0);
+      });
+      bgItem.appendChild(bgLabel);
+      bgItem.appendChild(bgInput);
+      familyPanel.appendChild(bgItem);
+
       FAMILY_LIST.forEach((family) => {
         const item = document.createElement('div');
         item.className = 'family-config-item';

--- a/styles.css
+++ b/styles.css
@@ -46,6 +46,7 @@ body {
 #visualizer {
   border: 1px solid #444;
   height: 720px;
+  background-color: #000;
 }
 
 #assignment-modal {

--- a/test_canvas_color.js
+++ b/test_canvas_color.js
@@ -1,0 +1,76 @@
+const assert = require('assert');
+const { JSDOM } = require('jsdom');
+
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+<canvas id="visualizer" width="800" height="720"></canvas>
+<button id="load-midi"></button>
+<input id="midi-file-input" />
+<button id="load-wav"></button>
+<input id="wav-file-input" />
+<select id="instrument-select"></select>
+<select id="family-select"></select>
+<button id="toggle-family-panel"></button>
+<div id="family-config-panel"></div>
+<div id="assignment-modal"></div>
+<div id="modal-instrument-list"></div>
+<div id="modal-family-zones"></div>
+<button id="apply-assignments"></button>
+<button id="play-stop"></button>
+<button id="seek-forward"></button>
+<button id="seek-backward"></button>
+<button id="restart"></button>
+<button id="aspect-16-9"></button>
+<button id="aspect-9-16"></button>
+<button id="full-screen"></button>
+</body></html>`, { runScripts: 'outside-only' });
+
+global.document = dom.window.document;
+global.window = dom.window;
+
+dom.window.HTMLCanvasElement.prototype.getContext = function() {
+  return {
+    fillStyle: '#000',
+    fillRect: function() {},
+    drawImage: function() {},
+    clearRect: function() {},
+    beginPath: function() {},
+    moveTo: function() {},
+    lineTo: function() {},
+    arc: function() {},
+    ellipse: function() {},
+    rect: function() {},
+    closePath: function() {},
+    fill: function() {},
+    stroke: function() {},
+  };
+};
+
+global.requestAnimationFrame = (cb) => setTimeout(cb, 0);
+global.cancelAnimationFrame = (id) => clearTimeout(id);
+
+require('./script.js');
+
+dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+
+const canvas = dom.window.document.getElementById('visualizer');
+const toHex = (val) => {
+  if (val.startsWith('#')) return val.toLowerCase();
+  const m = val.match(/\d+/g);
+  return (
+    '#' +
+    m
+      .slice(0, 3)
+      .map((n) => parseInt(n, 10).toString(16).padStart(2, '0'))
+      .join('')
+  );
+};
+
+assert.strictEqual(toHex(canvas.style.backgroundColor), '#000000');
+
+const colorInput = dom.window.document.getElementById('canvas-color-input');
+colorInput.value = '#123456';
+colorInput.dispatchEvent(new dom.window.Event('change'));
+
+assert.strictEqual(toHex(canvas.style.backgroundColor), '#123456');
+
+console.log('Pruebas de color de canvas completadas');

--- a/utils.js
+++ b/utils.js
@@ -62,12 +62,16 @@ function drawNoteShape(ctx, shape, x, y, width, height, stroke = false) {
       ctx.ellipse(x + width / 2, y + height / 2, width / 2, height / 2, 0, 0, Math.PI * 2);
       break;
     case 'capsule': {
-      const r = height / 2;
+      const r = Math.min(width, height) * 0.25;
       ctx.moveTo(x + r, y);
       ctx.lineTo(x + width - r, y);
-      ctx.arc(x + width - r, y + r, r, -Math.PI / 2, Math.PI / 2);
+      ctx.arc(x + width - r, y + r, r, -Math.PI / 2, 0);
+      ctx.lineTo(x + width, y + height - r);
+      ctx.arc(x + width - r, y + height - r, r, 0, Math.PI / 2);
       ctx.lineTo(x + r, y + height);
-      ctx.arc(x + r, y + r, r, Math.PI / 2, -Math.PI / 2, true);
+      ctx.arc(x + r, y + height - r, r, Math.PI / 2, Math.PI);
+      ctx.lineTo(x, y + r);
+      ctx.arc(x + r, y + r, r, Math.PI, -Math.PI / 2);
       break;
     }
     case 'star': {


### PR DESCRIPTION
## Summary
- add configurable canvas background color via panel
- draw capsule shapes as rounded rectangles
- test canvas background color changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9c00d8dd4833381ce6437403f16c9