### PR TITLE
Permitir reproducción solo con MIDI o solo con WAV

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -36,7 +36,7 @@
 36. [x] El color de fondo del canvas debe ser negro absoluto, pero en el panel inferior debe existir la posibilidad de cambiar el color del canvas.
 37. [x] La línea de presente debe ser invisible.
 38. [x] Las cápsulas deben ser rectángulos con esquinas redondeadas.
-39. [ ] El botón de play debe funcionar así esté cargado solo el MIDI/XML sin audio, o el audio sin MIDI/XML.
+39. [x] El botón de play debe funcionar así esté cargado solo el MIDI/XML sin audio, o el audio sin MIDI/XML.
 40. [ ] La animación debe estar en 60 fps fijos SIEMPRE, y no depender de la frecuencia de la pantalla.
 41. [ ] La velocidad del midi debe salir del tempo map, y NO ser una velocidad constante.
 42. [ ] El brillo de las figuras al pasar por la línea de presente debe ser de tipo glow/blur, y parecer una sombra más que una línea definida.
@@ -44,3 +44,4 @@
 44. [ ] En algún menú debe existir la posibilidad de activar o desactivar instrumentos para incluirlos o eliminarlos de la animación.
 45. [x] Crear pruebas unitarias para la personalización del color del canvas.
 46. [x] Corregir el bug que impedía aplicar el color de fondo seleccionado al canvas en cada frame.
+47. [ ] Crear pruebas unitarias para el botón Play funcionando con solo MIDI/XML o solo WAV.


### PR DESCRIPTION
## Summary
- Permite iniciar y detener la animación aunque solo se haya cargado MIDI o solo WAV
- Ajusta startPlayback, stopPlayback y seek para manejar ausencia de audio o notas
- Marca la tarea del botón Play en `agents_tareas` y agrega tarea para pruebas futuras

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9c317413c83339fcd01ec37636cca