### PR TITLE
Add unit tests for play button single source

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -44,4 +44,4 @@
 44. [ ] En algún menú debe existir la posibilidad de activar o desactivar instrumentos para incluirlos o eliminarlos de la animación.
 45. [x] Crear pruebas unitarias para la personalización del color del canvas.
 46. [x] Corregir el bug que impedía aplicar el color de fondo seleccionado al canvas en cada frame.
-47. [ ] Crear pruebas unitarias para el botón Play funcionando con solo MIDI/XML o solo WAV.
+47. [x] Crear pruebas unitarias para el botón Play funcionando con solo MIDI/XML o solo WAV.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js"
+    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js && node test_play_button_single_source.js"
   },
   "keywords": [],
   "author": "",

--- a/script.js
+++ b/script.js
@@ -15,6 +15,7 @@ const {
   calculateCanvasSize,
   computeSeekOffset,
   resetStartOffset,
+  canStartPlayback,
 } = typeof require !== 'undefined' ? require('./utils.js') : window.utils;
 
 // "initializeUI" se declara globalmente en ui.js cuando se carga en el navegador.
@@ -356,7 +357,7 @@ if (typeof document !== 'undefined') {
 
     function startPlayback() {
       const ctx = getAudioContext();
-      if (!audioBuffer && notes.length === 0) return;
+      if (!canStartPlayback(audioBuffer, notes)) return;
       playStartTime = ctx.currentTime;
       if (audioBuffer) {
         source = ctx.createBufferSource();

--- a/test_play_button_single_source.js
+++ b/test_play_button_single_source.js
@@ -1,0 +1,13 @@
+const assert = require('assert');
+const { canStartPlayback } = require('./utils.js');
+
+// No hay audio ni notas
+assert.strictEqual(canStartPlayback(null, []), false);
+
+// Solo audio
+assert.strictEqual(canStartPlayback({}, []), true);
+
+// Solo notas
+assert.strictEqual(canStartPlayback(null, [{ start: 0, end: 1 }]), true);
+
+console.log('Pruebas del botón Play con una sola fuente completadas');

--- a/utils.js
+++ b/utils.js
@@ -217,6 +217,12 @@ function resetStartOffset() {
   return 0;
 }
 
+// Determina si se puede iniciar la reproducción
+// Devuelve true si existe un buffer de audio o al menos una nota
+function canStartPlayback(audioBuffer, notes) {
+  return !!(audioBuffer || (Array.isArray(notes) && notes.length > 0));
+}
+
 const utils = {
   computeOpacity,
   computeBumpHeight,
@@ -230,6 +236,7 @@ const utils = {
   calculateCanvasSize,
   computeSeekOffset,
   resetStartOffset,
+  canStartPlayback,
 };
 
 if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
## Summary
- add `canStartPlayback` utility to check if playback can start with audio or notes
- use `canStartPlayback` in `startPlayback` and test it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9c4ee1f188333b8e0e2f53c1296b6