### PR TITLE
Add offscreen canvas rendering tests

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -30,7 +30,7 @@
 30. [x] Refactorizar la lógica de la interfaz en módulos separados y crear pruebas de integración básicas.
 31. [x] Optimizar el renderizado de notas utilizando técnicas de canvas offscreen.
 32. [x] Modularizar la lógica de carga de archivos MIDI y WAV en componentes separados.
-33. Crear pruebas unitarias para el renderizado mediante canvas offscreen.
+33. [x] Crear pruebas unitarias para el renderizado mediante canvas offscreen.
 34. [x] Modularizar la lógica de reproducción de audio en un componente separado.
 35. [x] Crear pruebas unitarias para la lógica modular de reproducción de audio.
 36. [x] El color de fondo del canvas debe ser negro absoluto, pero en el panel inferior debe existir la posibilidad de cambiar el color del canvas.
@@ -45,3 +45,9 @@
 45. [x] Crear pruebas unitarias para la personalización del color del canvas.
 46. [x] Corregir el bug que impedía aplicar el color de fondo seleccionado al canvas en cada frame.
 47. [x] Crear pruebas unitarias para el botón Play funcionando con solo MIDI/XML o solo WAV.
+
+48. [ ] Crear pruebas unitarias para mantener la animación a 60 fps constantes.
+49. [ ] Crear pruebas unitarias para la reproducción basada en el tempo map.
+50. [ ] Crear pruebas unitarias para el efecto de brillo tipo glow/blur.
+51. [ ] Verificar mediante pruebas la geometría equilátera de los triángulos.
+52. [ ] Crear pruebas unitarias para la activación y desactivación de instrumentos en la animación.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js && node test_play_button_single_source.js && node test_audio_player.js"
+    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js && node test_play_button_single_source.js && node test_audio_player.js && node test_offscreen_render.js"
   },
   "keywords": [],
   "author": "",

--- a/script.js
+++ b/script.js
@@ -530,6 +530,9 @@ if (typeof document !== 'undefined') {
     // Exponer la función para pruebas unitarias
     if (typeof window !== 'undefined') {
       window.__renderFrame = renderFrame;
+      window.__setTestNotes = (n) => {
+        notes = n;
+      };
     }
 
     function startAnimation() {

--- a/test_offscreen_render.js
+++ b/test_offscreen_render.js
@@ -1,0 +1,76 @@
+const assert = require('assert');
+const { JSDOM } = require('jsdom');
+
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+<canvas id="visualizer" width="800" height="720"></canvas>
+<button id="load-midi"></button>
+<input id="midi-file-input" />
+<button id="load-wav"></button>
+<input id="wav-file-input" />
+<select id="instrument-select"></select>
+<select id="family-select"></select>
+<button id="toggle-family-panel"></button>
+<div id="family-config-panel"></div>
+<div id="assignment-modal"></div>
+<div id="modal-instrument-list"></div>
+<div id="modal-family-zones"></div>
+<button id="apply-assignments"></button>
+<button id="play-stop"></button>
+<button id="seek-forward"></button>
+<button id="seek-backward"></button>
+<button id="restart"></button>
+<button id="aspect-16-9"></button>
+<button id="aspect-9-16"></button>
+<button id="full-screen"></button>
+</body></html>`, { runScripts: 'outside-only' });
+
+global.document = dom.window.document;
+global.window = dom.window;
+
+const contexts = [];
+const canvases = [];
+dom.window.HTMLCanvasElement.prototype.getContext = function() {
+  canvases.push(this);
+  const ctx = {
+    operations: [],
+    fillStyle: '#000',
+    lastDrawImageSource: null,
+    fillRect: function() { this.operations.push('fillRect'); },
+    clearRect: function() { this.operations.push('clearRect'); },
+    beginPath: function() { this.operations.push('beginPath'); },
+    moveTo: function() { this.operations.push('moveTo'); },
+    lineTo: function() { this.operations.push('lineTo'); },
+    arc: function() { this.operations.push('arc'); },
+    ellipse: function() { this.operations.push('ellipse'); },
+    rect: function() { this.operations.push('rect'); },
+    closePath: function() { this.operations.push('closePath'); },
+    fill: function() { this.operations.push('fill'); },
+    stroke: function() { this.operations.push('stroke'); },
+    save: function() { this.operations.push('save'); },
+    restore: function() { this.operations.push('restore'); },
+    drawImage: function(src) { this.lastDrawImageSource = src; this.operations.push('drawImage'); },
+    globalAlpha: 1,
+    lineWidth: 1,
+    strokeStyle: '#000',
+  };
+  contexts.push(ctx);
+  return ctx;
+};
+
+global.requestAnimationFrame = (cb) => setTimeout(cb, 0);
+global.cancelAnimationFrame = (id) => clearTimeout(id);
+
+require('./script.js');
+
+dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+
+dom.window.__setTestNotes([
+  { start: 0, end: 1, noteNumber: 60, color: '#ff0000', shape: 'square', family: 'Metales' },
+]);
+
+dom.window.__renderFrame(0);
+
+assert(contexts[1].operations.includes('rect'), 'La nota no se dibujó en el offscreen canvas');
+assert.strictEqual(contexts[0].lastDrawImageSource, canvases[1], 'El canvas principal no recibió la imagen del offscreen');
+
+console.log('Pruebas de renderizado offscreen completadas');


### PR DESCRIPTION
## Summary
- expose test hook to inject note data for rendering validation
- add unit test ensuring notes render via offscreen canvas
- document completed task and plan follow-up testing tasks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9c8f3a9688333938dd49e333898f0