### PR TITLE
Add instrument activation controls

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -41,7 +41,7 @@
 41. [ ] La velocidad del midi debe salir del tempo map, y NO ser una velocidad constante.
 42. [ ] El brillo de las figuras al pasar por la línea de presente debe ser de tipo glow/blur, y parecer una sombra más que una línea definida.
 43. [x] Los triángulos deben ser equiláteros con el ángulo superior al medio de la figura.
-44. [ ] En algún menú debe existir la posibilidad de activar o desactivar instrumentos para incluirlos o eliminarlos de la animación.
+44. [x] En algún menú debe existir la posibilidad de activar o desactivar instrumentos para incluirlos o eliminarlos de la animación.
 45. [x] Crear pruebas unitarias para la personalización del color del canvas.
 46. [x] Corregir el bug que impedía aplicar el color de fondo seleccionado al canvas en cada frame.
 47. [x] Crear pruebas unitarias para el botón Play funcionando con solo MIDI/XML o solo WAV.
@@ -50,5 +50,6 @@
 49. [ ] Crear pruebas unitarias para la reproducción basada en el tempo map.
 50. [ ] Crear pruebas unitarias para el efecto de brillo tipo glow/blur.
 51. [x] Verificar mediante pruebas la geometría equilátera de los triángulos.
-52. [ ] Crear pruebas unitarias para la activación y desactivación de instrumentos en la animación.
+52. [x] Crear pruebas unitarias para la activación y desactivación de instrumentos en la animación.
 53. [x] Eliminar pruebas unitarias redundantes para simplificar la suite.
+54. [ ] Persistir el estado de activación de instrumentos en la configuración local.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js && node test_audio_player.js && node test_offscreen_render.js"
+    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js && node test_audio_player.js && node test_offscreen_render.js && node test_instrument_toggle.js"
   },
   "keywords": [],
   "author": "",

--- a/test_instrument_toggle.js
+++ b/test_instrument_toggle.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+const { getVisibleNotes, setInstrumentEnabled } = require('./script');
+
+const notes = [
+  { instrument: 'Flauta', start: 0, end: 1, noteNumber: 60, color: '#fff', shape: 'oval', family: 'Maderas de timbre "redondo"' },
+  { instrument: 'Violin', start: 0, end: 1, noteNumber: 65, color: '#fff', shape: 'triangle', family: 'Cuerdas frotadas' },
+];
+
+setInstrumentEnabled('Flauta', false);
+setInstrumentEnabled('Violin', true);
+
+const visible = getVisibleNotes(notes);
+assert.strictEqual(visible.length, 1);
+assert.strictEqual(visible[0].instrument, 'Violin');
+
+console.log('Pruebas de activación/desactivación de instrumentos completadas');


### PR DESCRIPTION
## Summary
- Allow toggling instrument visibility via checkboxes in family panel
- Filter note rendering based on active instruments and include unit test
- Update tasks list to reflect completed instrument toggling feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9cb7650b083338f92824f7782f02d