### PR TITLE
Implement tempo-map playback, fixed 60fps loop, glow blur, and instrument persistence

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -37,19 +37,21 @@
 37. [x] La línea de presente debe ser invisible.
 38. [x] Las cápsulas deben ser rectángulos con esquinas redondeadas.
 39. [x] El botón de play debe funcionar así esté cargado solo el MIDI/XML sin audio, o el audio sin MIDI/XML.
-40. [ ] La animación debe estar en 60 fps fijos SIEMPRE, y no depender de la frecuencia de la pantalla.
-41. [ ] La velocidad del midi debe salir del tempo map, y NO ser una velocidad constante.
-42. [ ] El brillo de las figuras al pasar por la línea de presente debe ser de tipo glow/blur, y parecer una sombra más que una línea definida.
+40. [x] La animación debe estar en 60 fps fijos SIEMPRE, y no depender de la frecuencia de la pantalla.
+41. [x] La velocidad del midi debe salir del tempo map, y NO ser una velocidad constante.
+42. [x] El brillo de las figuras al pasar por la línea de presente debe ser de tipo glow/blur, y parecer una sombra más que una línea definida.
 43. [x] Los triángulos deben ser equiláteros con el ángulo superior al medio de la figura.
 44. [x] En algún menú debe existir la posibilidad de activar o desactivar instrumentos para incluirlos o eliminarlos de la animación.
 45. [x] Crear pruebas unitarias para la personalización del color del canvas.
 46. [x] Corregir el bug que impedía aplicar el color de fondo seleccionado al canvas en cada frame.
 47. [x] Crear pruebas unitarias para el botón Play funcionando con solo MIDI/XML o solo WAV.
 
-48. [ ] Crear pruebas unitarias para mantener la animación a 60 fps constantes.
-49. [ ] Crear pruebas unitarias para la reproducción basada en el tempo map.
-50. [ ] Crear pruebas unitarias para el efecto de brillo tipo glow/blur.
+48. [x] Crear pruebas unitarias para mantener la animación a 60 fps constantes.
+49. [x] Crear pruebas unitarias para la reproducción basada en el tempo map.
+50. [x] Crear pruebas unitarias para el efecto de brillo tipo glow/blur.
 51. [x] Verificar mediante pruebas la geometría equilátera de los triángulos.
 52. [x] Crear pruebas unitarias para la activación y desactivación de instrumentos en la animación.
 53. [x] Eliminar pruebas unitarias redundantes para simplificar la suite.
-54. [ ] Persistir el estado de activación de instrumentos en la configuración local.
+54. [x] Persistir el estado de activación de instrumentos en la configuración local.
+55. [ ] Crear pruebas unitarias para la persistencia del estado de activación de instrumentos.
+56. [ ] Optimizar la conversión de ticks a segundos utilizando un mapa de tempo preprocesado.

--- a/midiLoader.js
+++ b/midiLoader.js
@@ -12,12 +12,11 @@
         reader.onload = (ev) => {
           try {
             const midi = parsers.parseMIDI(ev.target.result);
-            const tempoEvent = midi.tracks
-              .flatMap((t) => t.events)
-              .find((e) => e.type === 'tempo');
-            const microPerBeat = tempoEvent ? tempoEvent.microsecondsPerBeat : 500000;
-            const secondsPerTick = microPerBeat / 1e6 / midi.timeDivision;
-            resolve({ tracks: midi.tracks, secondsPerUnit: secondsPerTick });
+            resolve({
+              tracks: midi.tracks,
+              tempoMap: midi.tempoMap,
+              timeDivision: midi.timeDivision,
+            });
           } catch (err) {
             reject(err);
           }
@@ -27,8 +26,17 @@
         reader.onload = (ev) => {
           try {
             const xml = parsers.parseMusicXML(ev.target.result);
-            const secondsPerDiv = (60 / xml.tempo) / xml.divisions;
-            resolve({ tracks: xml.tracks, secondsPerUnit: secondsPerDiv });
+            const tempoMap = [
+              {
+                time: 0,
+                microsecondsPerBeat: (60 / xml.tempo) * 1e6,
+              },
+            ];
+            resolve({
+              tracks: xml.tracks,
+              tempoMap,
+              timeDivision: xml.divisions,
+            });
           } catch (err) {
             reject(err);
           }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js && node test_audio_player.js && node test_offscreen_render.js && node test_instrument_toggle.js"
+    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js && node test_audio_player.js && node test_offscreen_render.js && node test_instrument_toggle.js && node test_tempo_map.js && node test_fixed_fps.js"
   },
   "keywords": [],
   "author": "",

--- a/test_config_export_import.js
+++ b/test_config_export_import.js
@@ -12,6 +12,7 @@ const tracks = assignTrackInfo([{ name: 'Flauta', events: [] }]);
 const config = {
   assignedFamilies: { Flauta: 'Metales' },
   familyCustomizations: { Metales: { color: '#123456', shape: 'triangle' } },
+  enabledInstruments: { Flauta: true },
 };
 
 importConfiguration(config, tracks);

--- a/test_fixed_fps.js
+++ b/test_fixed_fps.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const { startFixedFPSLoop } = require('./script');
+
+const origSetInterval = global.setInterval;
+const origClearInterval = global.clearInterval;
+let capturedDelay = null;
+let cleared = false;
+
+global.setInterval = (fn, delay) => {
+  capturedDelay = delay;
+  return 1;
+};
+global.clearInterval = (id) => {
+  if (id === 1) cleared = true;
+};
+
+const stop = startFixedFPSLoop(() => {});
+assert(Math.abs(capturedDelay - 1000 / 60) < 1e-6);
+stop();
+assert(cleared);
+
+global.setInterval = origSetInterval;
+global.clearInterval = origClearInterval;
+
+console.log('Pruebas de FPS constantes completadas');

--- a/test_tempo_map.js
+++ b/test_tempo_map.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+const { ticksToSeconds } = require('./script');
+
+const tempoMap = [
+  { time: 0, microsecondsPerBeat: 500000 },
+  { time: 480, microsecondsPerBeat: 250000 },
+];
+const timeDivision = 480;
+
+const t1 = ticksToSeconds(480, tempoMap, timeDivision);
+const t2 = ticksToSeconds(960, tempoMap, timeDivision);
+assert(Math.abs(t1 - 0.5) < 1e-6);
+assert(Math.abs(t2 - 0.75) < 1e-6);
+
+console.log('Pruebas del tempo map completadas');

--- a/test_visual_effects.js
+++ b/test_visual_effects.js
@@ -1,5 +1,10 @@
 const assert = require('assert');
-const { computeOpacity, computeBumpHeight, computeGlowAlpha } = require('./script');
+const {
+  computeOpacity,
+  computeBumpHeight,
+  computeGlowAlpha,
+  applyGlowEffect,
+} = require('./script');
 
 function approx(actual, expected, eps = 1e-6) {
   assert(Math.abs(actual - expected) < eps, `${actual} != ${expected}`);
@@ -22,5 +27,24 @@ approx(computeBumpHeight(base, 0, 0, 1, 0.8), 18); // Bump +30%
 approx(computeGlowAlpha(0, 0), 1); // Inicio del brillo
 approx(computeGlowAlpha(0.1, 0), 0.5); // Mitad del efecto
 approx(computeGlowAlpha(0.25, 0), 0); // Efecto terminado
+
+// Prueba para applyGlowEffect con desenfoque
+const glowCtx = {
+  shadowBlur: 0,
+  shadowColor: null,
+  fillStyle: null,
+  save() {},
+  restore() {},
+  beginPath() {},
+  rect() {},
+  fillCalled: false,
+  fill() {
+    this.fillCalled = true;
+  },
+};
+applyGlowEffect(glowCtx, 'square', 0, 0, 10, 10, 0.5);
+assert(glowCtx.shadowBlur > 0, 'shadowBlur no aplicado');
+assert.strictEqual(glowCtx.fillStyle, '#ffffff');
+assert(glowCtx.fillCalled, 'fill no llamado en glow');
 
 console.log('Pruebas de efectos visuales completadas');


### PR DESCRIPTION
## Summary
- Keep animation at steady 60fps using a fixed interval loop
- Convert MIDI ticks via tempo map and apply glow blur effect
- Persist instrument activation state and extend configuration export
- Add unit tests for tempo map conversion, fixed FPS, and glow blur

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9cd470be88333b91e7339d0366ea8