### PR TITLE
Optimize tempo map and scale notes by velocity

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -53,11 +53,11 @@
 52. [x] Crear pruebas unitarias para la activación y desactivación de instrumentos en la animación.
 53. [x] Eliminar pruebas unitarias redundantes para simplificar la suite.
 54. [x] Persistir el estado de activación de instrumentos en la configuración local.
-55. [ ] Crear pruebas unitarias para la persistencia del estado de activación de instrumentos.
-56. [ ] Optimizar la conversión de ticks a segundos utilizando un mapa de tempo preprocesado.
-57. [ ] Modificar la altura de las figuras geométricas para que ocupen el 100% de una de las 88 divisiones verticales del canvas.
-58. [ ] Implementar una función para que la altura de las figuras varíe proporcionalmente a la velocidad MIDI, tomando como referencia que la velocidad 67 equivale al 100% de la altura predeterminada.
-59. [ ] Corregir el reconocimiento de tildes en los nombres de los instrumentos.
+55. [x] Crear pruebas unitarias para la persistencia del estado de activación de instrumentos.
+56. [x] Optimizar la conversión de ticks a segundos utilizando un mapa de tempo preprocesado.
+57. [x] Modificar la altura de las figuras geométricas para que ocupen el 100% de una de las 88 divisiones verticales del canvas.
+58. [x] Implementar una función para que la altura de las figuras varíe proporcionalmente a la velocidad MIDI, tomando como referencia que la velocidad 67 equivale al 100% de la altura predeterminada.
+59. [x] Corregir el reconocimiento de tildes en los nombres de los instrumentos.
 60. [ ] Corregir la figura triángulo y triángulo alargado para que tengan su punto de alineación en su esquina izquierda.
 61. [ ] Crear el botón "Modo desarrollador" que habilite opciones avanzadas en el panel inferior.
 62. [ ] Permitir definir rangos de tono de color para las familias, eligiendo el color más brillante y el más oscuro para calcular matices intermedios.
@@ -65,3 +65,5 @@
 64. [ ] Agregar un control porcentual para manejar el tamaño, la difuminación y la duración del glow.
 65. [ ] Agregar un control porcentual para manejar la cantidad de bump y el tiempo de regreso al tamaño normal.
 66. [ ] Agregar un control para definir la velocidad base donde 67 (número editable) represente el 100%.
+67. [x] Crear pruebas unitarias para la variación de altura basada en velocidad MIDI.
+68. [x] Crear pruebas unitarias para el reconocimiento de tildes en los nombres de los instrumentos.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js && node test_audio_player.js && node test_offscreen_render.js && node test_instrument_toggle.js && node test_tempo_map.js && node test_fixed_fps.js"
+    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js && node test_audio_player.js && node test_offscreen_render.js && node test_instrument_toggle.js && node test_tempo_map.js && node test_fixed_fps.js && node test_instrument_persistence.js && node test_velocity_height.js && node test_instrument_accents.js"
   },
   "keywords": [],
   "author": "",

--- a/test_instrument_accents.js
+++ b/test_instrument_accents.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const { assignTrackInfo } = require('./script');
+
+const tracks = assignTrackInfo([
+  { name: 'Saxofon', events: [] },
+  { name: 'Corno frances', events: [] },
+]);
+
+assert.strictEqual(tracks[0].instrument, 'Saxofón');
+assert.strictEqual(tracks[0].family, 'Saxofones');
+assert.strictEqual(tracks[1].instrument, 'Corno francés');
+assert.strictEqual(tracks[1].family, 'Metales');
+
+console.log('Pruebas de reconocimiento de tildes completadas');

--- a/test_instrument_persistence.js
+++ b/test_instrument_persistence.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+
+const store = {};
+global.localStorage = {
+  getItem: (k) => store[k],
+  setItem: (k, v) => {
+    store[k] = v;
+  },
+};
+
+let { setInstrumentEnabled, getVisibleNotes } = require('./script');
+
+const notes = [
+  { instrument: 'Flauta', start: 0, end: 1, noteNumber: 60, color: '#fff', shape: 'oval', family: 'Maderas de timbre "redondo"', velocity: 67 },
+  { instrument: 'Violin', start: 0, end: 1, noteNumber: 65, color: '#fff', shape: 'triangle', family: 'Cuerdas frotadas', velocity: 67 },
+];
+
+setInstrumentEnabled('Flauta', false);
+setInstrumentEnabled('Violin', true);
+
+delete require.cache[require.resolve('./script')];
+({ getVisibleNotes } = require('./script'));
+
+const visible = getVisibleNotes(notes);
+assert.strictEqual(visible.length, 1);
+assert.strictEqual(visible[0].instrument, 'Violin');
+
+console.log('Pruebas de persistencia de instrumentos completadas');

--- a/test_tempo_map.js
+++ b/test_tempo_map.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { ticksToSeconds } = require('./script');
+const { ticksToSeconds, preprocessTempoMap } = require('./script');
 
 const tempoMap = [
   { time: 0, microsecondsPerBeat: 500000 },
@@ -7,8 +7,9 @@ const tempoMap = [
 ];
 const timeDivision = 480;
 
-const t1 = ticksToSeconds(480, tempoMap, timeDivision);
-const t2 = ticksToSeconds(960, tempoMap, timeDivision);
+const pre = preprocessTempoMap(tempoMap, timeDivision);
+const t1 = ticksToSeconds(480, pre, timeDivision);
+const t2 = ticksToSeconds(960, pre, timeDivision);
 assert(Math.abs(t1 - 0.5) < 1e-6);
 assert(Math.abs(t2 - 0.75) < 1e-6);
 

--- a/test_velocity_height.js
+++ b/test_velocity_height.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+const { computeVelocityHeight } = require('./script');
+
+const base = 10;
+assert.strictEqual(computeVelocityHeight(base, 67), base);
+assert.strictEqual(computeVelocityHeight(base, 134), base * 2);
+assert(Math.abs(computeVelocityHeight(base, 33) - base * (33 / 67)) < 1e-6);
+
+console.log('Pruebas de altura por velocidad completadas');


### PR DESCRIPTION
## Summary
- Normalize instrument names to handle tildes and map families correctly
- Preprocess tempo maps for faster tick-to-second conversion and scale note height by MIDI velocity
- Add unit tests for instrument persistence, velocity scaling and accent recognition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9d2dbf1a88333a232aba6ae3d4325