### PR TITLE
Align triangle shapes and introduce developer mode

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -58,8 +58,8 @@
 57. [x] Modificar la altura de las figuras geométricas para que ocupen el 100% de una de las 88 divisiones verticales del canvas.
 58. [x] Implementar una función para que la altura de las figuras varíe proporcionalmente a la velocidad MIDI, tomando como referencia que la velocidad 67 equivale al 100% de la altura predeterminada.
 59. [x] Corregir el reconocimiento de tildes en los nombres de los instrumentos.
-60. [ ] Corregir la figura triángulo y triángulo alargado para que tengan su punto de alineación en su esquina izquierda.
-61. [ ] Crear el botón "Modo desarrollador" que habilite opciones avanzadas en el panel inferior.
+60. [x] Corregir la figura triángulo y triángulo alargado para que tengan su punto de alineación en su esquina izquierda.
+61. [x] Crear el botón "Modo desarrollador" que habilite opciones avanzadas en el panel inferior.
 62. [ ] Permitir definir rangos de tono de color para las familias, eligiendo el color más brillante y el más oscuro para calcular matices intermedios.
 63. [ ] Agregar controles con porcentajes que modifiquen la escala de opacidad en los diferentes puntos del canvas.
 64. [ ] Agregar un control porcentual para manejar el tamaño, la difuminación y la duración del glow.
@@ -67,3 +67,8 @@
 66. [ ] Agregar un control para definir la velocidad base donde 67 (número editable) represente el 100%.
 67. [x] Crear pruebas unitarias para la variación de altura basada en velocidad MIDI.
 68. [x] Crear pruebas unitarias para el reconocimiento de tildes en los nombres de los instrumentos.
+69. [ ] Crear pruebas unitarias para los rangos de tono de color por familia.
+70. [ ] Crear pruebas unitarias para la escala de opacidad configurable.
+71. [ ] Crear pruebas unitarias para el control de tamaño, difuminación y duración del glow.
+72. [ ] Crear pruebas unitarias para el control de cantidad y duración del bump.
+73. [ ] Crear pruebas unitarias para la definición de la velocidad base.

--- a/index.html
+++ b/index.html
@@ -55,9 +55,12 @@
       <option>Voces</option>
     </select>
     <button id="toggle-family-panel">▼</button>
+    <button id="developer-mode">Modo desarrollador</button>
   </nav>
 
-  <div id="family-config-panel" class="hidden"></div>
+  <div id="family-config-panel" class="hidden">
+    <div id="developer-controls" class="hidden"></div>
+  </div>
 
   <div id="assignment-modal" class="hidden">
     <div class="modal-content">

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js && node test_audio_player.js && node test_offscreen_render.js && node test_instrument_toggle.js && node test_tempo_map.js && node test_fixed_fps.js && node test_instrument_persistence.js && node test_velocity_height.js && node test_instrument_accents.js"
+    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js && node test_audio_player.js && node test_offscreen_render.js && node test_instrument_toggle.js && node test_tempo_map.js && node test_fixed_fps.js && node test_instrument_persistence.js && node test_velocity_height.js && node test_instrument_accents.js && node test_developer_mode.js"
   },
   "keywords": [],
   "author": "",

--- a/script.js
+++ b/script.js
@@ -25,7 +25,7 @@ const {
 // "initializeUI" se declara globalmente en ui.js cuando se carga en el navegador.
 // Para evitar un error de "Identifier has already been declared" al importar
 // la función en este archivo, renombramos la referencia local.
-const { initializeUI: initializeUIControls } =
+const { initializeUI: initializeUIControls, initializeDeveloperMode } =
   typeof require !== 'undefined' ? require('./ui.js') : window.ui;
 const { loadMusicFile } =
   typeof require !== 'undefined' ? require('./midiLoader.js') : window.midiLoader;
@@ -76,10 +76,14 @@ if (typeof document !== 'undefined') {
     const familySelect = document.getElementById('family-select');
     const toggleFamilyPanelBtn = document.getElementById('toggle-family-panel');
     const familyPanel = document.getElementById('family-config-panel');
+    const developerBtn = document.getElementById('developer-mode');
+    const developerControls = document.getElementById('developer-controls');
     const assignmentModal = document.getElementById('assignment-modal');
     const modalInstrumentList = document.getElementById('modal-instrument-list');
     const modalFamilyZones = document.getElementById('modal-family-zones');
     const applyAssignmentsBtn = document.getElementById('apply-assignments');
+    initializeDeveloperMode({ button: developerBtn, panel: developerControls });
+
     let currentTracks = [];
     let notes = [];
     const NOTE_MIN = 21;

--- a/test_canvas_color.js
+++ b/test_canvas_color.js
@@ -10,7 +10,8 @@ const dom = new JSDOM(`<!DOCTYPE html><html><body>
 <select id="instrument-select"></select>
 <select id="family-select"></select>
 <button id="toggle-family-panel"></button>
-<div id="family-config-panel"></div>
+<button id="developer-mode"></button>
+<div id="family-config-panel"><div id="developer-controls"></div></div>
 <div id="assignment-modal"></div>
 <div id="modal-instrument-list"></div>
 <div id="modal-family-zones"></div>

--- a/test_developer_mode.js
+++ b/test_developer_mode.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const { JSDOM } = require('jsdom');
+const { initializeDeveloperMode } = require('./ui');
+
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+<button id="dev-btn"></button>
+<div id="panel" class="hidden"></div>
+</body></html>`);
+
+global.document = dom.window.document;
+
+const { isActive } = initializeDeveloperMode({
+  button: document.getElementById('dev-btn'),
+  panel: document.getElementById('panel'),
+});
+
+document.getElementById('dev-btn').click();
+assert.strictEqual(isActive(), true);
+assert.strictEqual(
+  document.getElementById('panel').classList.contains('hidden'),
+  false
+);
+
+document.getElementById('dev-btn').click();
+assert.strictEqual(isActive(), false);
+assert.strictEqual(
+  document.getElementById('panel').classList.contains('hidden'),
+  true
+);
+
+console.log('Pruebas de modo desarrollador completadas');

--- a/test_offscreen_render.js
+++ b/test_offscreen_render.js
@@ -10,7 +10,8 @@ const dom = new JSDOM(`<!DOCTYPE html><html><body>
 <select id="instrument-select"></select>
 <select id="family-select"></select>
 <button id="toggle-family-panel"></button>
-<div id="family-config-panel"></div>
+<button id="developer-mode"></button>
+<div id="family-config-panel"><div id="developer-controls"></div></div>
 <div id="assignment-modal"></div>
 <div id="modal-instrument-list"></div>
 <div id="modal-family-zones"></div>

--- a/test_shapes.js
+++ b/test_shapes.js
@@ -83,4 +83,21 @@ const tol = 1e-6;
 assert(Math.abs(a - b) < tol && Math.abs(b - c) < tol, 'lados no iguales');
 assert(Math.abs(top[0] - 5) < tol, 'vértice superior no centrado');
 
+// Verificación de alineación a la izquierda para triángulo alargado
+const triCtxWide = {
+  path: [],
+  beginPath() {},
+  moveTo(x, y) {
+    this.path.push([x, y]);
+  },
+  lineTo(x, y) {
+    this.path.push([x, y]);
+  },
+  closePath() {},
+  fill() {},
+};
+drawNoteShape(triCtxWide, 'triangle', 0, 0, 20, 10);
+const minX = Math.min(...triCtxWide.path.map((p) => p[0]));
+assert.strictEqual(minX, 0, 'triángulo alargado no alineado a la izquierda');
+
 console.log('Pruebas de figuras geométricas completadas');

--- a/ui.js
+++ b/ui.js
@@ -46,8 +46,21 @@ function initializeUI({
   };
 }
 
+function initializeDeveloperMode({ button, panel }) {
+  let active = false;
+  button.addEventListener('click', () => {
+    active = !active;
+    panel.classList.toggle('hidden', !active);
+  });
+  return {
+    isActive: () => active,
+    button,
+    panel,
+  };
+}
+
 if (typeof module !== 'undefined') {
-  module.exports = { initializeUI };
+  module.exports = { initializeUI, initializeDeveloperMode };
 } else {
-  window.ui = { initializeUI };
+  window.ui = { initializeUI, initializeDeveloperMode };
 }

--- a/utils.js
+++ b/utils.js
@@ -110,11 +110,10 @@ function drawNoteShape(ctx, shape, x, y, width, height, stroke = false) {
     case 'triangle': {
       const side = Math.min(width, (2 / Math.sqrt(3)) * height);
       const h = (Math.sqrt(3) / 2) * side;
-      const offsetX = x + (width - side) / 2;
       const offsetY = y + (height - h);
-      ctx.moveTo(x + width / 2, offsetY);
-      ctx.lineTo(offsetX + side, offsetY + h);
-      ctx.lineTo(offsetX, offsetY + h);
+      ctx.moveTo(x + side / 2, offsetY);
+      ctx.lineTo(x + side, offsetY + h);
+      ctx.lineTo(x, offsetY + h);
       ctx.closePath();
       break;
     }


### PR DESCRIPTION
## Summary
- Align triangle drawing to start at the left edge for both regular and stretched triangles
- Add "Modo desarrollador" button and basic infrastructure for advanced controls
- Extend test suite with developer mode and triangle alignment checks and update incremental plan

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9d57aa8148333829cf438f56e894e