### PR TITLE
Add base velocity control with tests

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -64,11 +64,13 @@
 63. [ ] Agregar controles con porcentajes que modifiquen la escala de opacidad en los diferentes puntos del canvas.
 64. [ ] Agregar un control porcentual para manejar el tamaño, la difuminación y la duración del glow.
 65. [ ] Agregar un control porcentual para manejar la cantidad de bump y el tiempo de regreso al tamaño normal.
-66. [ ] Agregar un control para definir la velocidad base donde 67 (número editable) represente el 100%.
+66. [x] Agregar un control para definir la velocidad base donde 67 (número editable) represente el 100%.
 67. [x] Crear pruebas unitarias para la variación de altura basada en velocidad MIDI.
 68. [x] Crear pruebas unitarias para el reconocimiento de tildes en los nombres de los instrumentos.
 69. [ ] Crear pruebas unitarias para los rangos de tono de color por familia.
 70. [ ] Crear pruebas unitarias para la escala de opacidad configurable.
 71. [ ] Crear pruebas unitarias para el control de tamaño, difuminación y duración del glow.
 72. [ ] Crear pruebas unitarias para el control de cantidad y duración del bump.
-73. [ ] Crear pruebas unitarias para la definición de la velocidad base.
+73. [x] Crear pruebas unitarias para la definición de la velocidad base.
+74. [ ] Persistir la velocidad base en la configuración local.
+75. [ ] Crear pruebas unitarias para la persistencia de la velocidad base.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js && node test_audio_player.js && node test_offscreen_render.js && node test_instrument_toggle.js && node test_tempo_map.js && node test_fixed_fps.js && node test_instrument_persistence.js && node test_velocity_height.js && node test_instrument_accents.js && node test_developer_mode.js"
+    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js && node test_audio_player.js && node test_offscreen_render.js && node test_instrument_toggle.js && node test_tempo_map.js && node test_fixed_fps.js && node test_instrument_persistence.js && node test_velocity_height.js && node test_instrument_accents.js && node test_developer_mode.js && node test_velocity_base.js"
   },
   "keywords": [],
   "author": "",

--- a/script.js
+++ b/script.js
@@ -18,6 +18,8 @@ const {
   applyGlowEffect,
   startFixedFPSLoop,
   computeVelocityHeight,
+  setVelocityBase,
+  getVelocityBase,
   preprocessTempoMap,
   ticksToSeconds,
 } = typeof require !== 'undefined' ? require('./utils.js') : window.utils;
@@ -84,7 +86,29 @@ if (typeof document !== 'undefined') {
     const modalInstrumentList = document.getElementById('modal-instrument-list');
     const modalFamilyZones = document.getElementById('modal-family-zones');
     const applyAssignmentsBtn = document.getElementById('apply-assignments');
-    initDeveloperMode({ button: developerBtn, panel: developerControls });
+    let velocityBase = getVelocityBase();
+
+    if (developerBtn && developerControls) {
+      initDeveloperMode({ button: developerBtn, panel: developerControls });
+
+      // Control para ajustar la velocidad base de referencia
+      const velLabel = document.createElement('label');
+      velLabel.textContent = 'Velocidad base:';
+      const velInput = document.createElement('input');
+      velInput.type = 'number';
+      velInput.min = '1';
+      velInput.max = '127';
+      velInput.value = velocityBase;
+      velInput.addEventListener('change', () => {
+        const val = parseInt(velInput.value, 10);
+        if (!isNaN(val)) {
+          velocityBase = Math.max(1, Math.min(127, val));
+          setVelocityBase(velocityBase);
+        }
+      });
+      developerControls.appendChild(velLabel);
+      developerControls.appendChild(velInput);
+    }
 
     let currentTracks = [];
     let notes = [];
@@ -541,7 +565,7 @@ if (typeof document !== 'undefined') {
       getVisibleNotes(notes).forEach((n) => {
         const { sizeFactor, bump } = getFamilyModifiers(n.family);
         let baseHeight = noteHeight * sizeFactor;
-        baseHeight = computeVelocityHeight(baseHeight, n.velocity || 67);
+          baseHeight = computeVelocityHeight(baseHeight, n.velocity || velocityBase);
         let xStart;
         let xEnd;
         let width;
@@ -1011,11 +1035,13 @@ if (typeof module !== 'undefined') {
     computeNoteWidth,
     calculateCanvasSize,
     NON_STRETCHED_SHAPES,
-    startFixedFPSLoop,
-    computeVelocityHeight,
-    preprocessTempoMap,
-    ticksToSeconds,
-    setFamilyCustomization,
+      startFixedFPSLoop,
+      computeVelocityHeight,
+      setVelocityBase,
+      getVelocityBase,
+      preprocessTempoMap,
+      ticksToSeconds,
+      setFamilyCustomization,
     resetFamilyCustomizations,
     exportConfiguration,
     importConfiguration,

--- a/test_velocity_base.js
+++ b/test_velocity_base.js
@@ -1,0 +1,13 @@
+const assert = require('assert');
+const { setVelocityBase, getVelocityBase, computeVelocityHeight } = require('./script');
+
+// Ajusta la velocidad base y verifica su efecto en la altura calculada
+setVelocityBase(80);
+assert.strictEqual(getVelocityBase(), 80);
+const base = 10;
+// Con velocidad igual a la base, la altura debe mantenerse
+assert.strictEqual(computeVelocityHeight(base, 80), base);
+// Con la mitad de la velocidad base, la altura debe ser la mitad
+assert.strictEqual(computeVelocityHeight(base, 40), base * 0.5);
+
+console.log('Pruebas de definición de velocidad base completadas');

--- a/utils.js
+++ b/utils.js
@@ -47,8 +47,21 @@ function computeBumpHeight(baseHeight, currentSec, start, end, bump = 0.5) {
   return baseHeight * (1 + bump * (1 - clamped));
 }
 
+// Referencia de velocidad MIDI para altura 100%
+let velocityBase = 67;
+
+// Permite definir una nueva velocidad base
+function setVelocityBase(value) {
+  velocityBase = value;
+}
+
+// Devuelve la velocidad base actual
+function getVelocityBase() {
+  return velocityBase;
+}
+
 // Escala la altura base de la nota según la velocidad MIDI
-function computeVelocityHeight(baseHeight, velocity, reference = 67) {
+function computeVelocityHeight(baseHeight, velocity, reference = velocityBase) {
   return baseHeight * (velocity / reference);
 }
 
@@ -288,6 +301,8 @@ const utils = {
   drawNoteShape,
   adjustColorBrightness,
   computeVelocityHeight,
+  setVelocityBase,
+  getVelocityBase,
   NON_STRETCHED_SHAPES,
   SHAPE_OPTIONS,
   getFamilyModifiers,


### PR DESCRIPTION
## Summary
- allow adjusting MIDI velocity reference with a developer panel control
- expose getter/setter for velocity base and apply it when computing note height
- cover velocity base logic with new unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9d7d795688333adcc1c23de0b8681