### PR TITLE
Persist velocity base setting

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -72,5 +72,7 @@
 71. [ ] Crear pruebas unitarias para el control de tamaño, difuminación y duración del glow.
 72. [ ] Crear pruebas unitarias para el control de cantidad y duración del bump.
 73. [x] Crear pruebas unitarias para la definición de la velocidad base.
-74. [ ] Persistir la velocidad base en la configuración local.
-75. [ ] Crear pruebas unitarias para la persistencia de la velocidad base.
+74. [x] Persistir la velocidad base en la configuración local.
+75. [x] Crear pruebas unitarias para la persistencia de la velocidad base.
+76. [ ] Incluir la velocidad base en la exportación e importación de configuraciones.
+77. [ ] Crear pruebas unitarias para la exportación e importación de la velocidad base.

--- a/test_velocity_base_persistence.js
+++ b/test_velocity_base_persistence.js
@@ -1,0 +1,24 @@
+const assert = require('assert');
+
+const store = {};
+global.localStorage = {
+  getItem: (k) => store[k],
+  setItem: (k, v) => {
+    store[k] = v;
+  },
+};
+
+let { setVelocityBase } = require('./script');
+
+// Establece y persiste la velocidad base
+setVelocityBase(90);
+
+// Fuerza la recarga de módulos para simular una nueva sesión
+delete require.cache[require.resolve('./script')];
+delete require.cache[require.resolve('./utils.js')];
+({ getVelocityBase } = require('./script'));
+
+// Debe recuperar el valor persistido
+assert.strictEqual(getVelocityBase(), 90);
+
+console.log('Pruebas de persistencia de la velocidad base completadas');

--- a/utils.js
+++ b/utils.js
@@ -53,10 +53,19 @@ let velocityBase = 67;
 // Permite definir una nueva velocidad base
 function setVelocityBase(value) {
   velocityBase = value;
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('velocityBase', String(velocityBase));
+  }
 }
 
 // Devuelve la velocidad base actual
 function getVelocityBase() {
+  if (typeof localStorage !== 'undefined') {
+    const stored = parseInt(localStorage.getItem('velocityBase'), 10);
+    if (!isNaN(stored)) {
+      velocityBase = stored;
+    }
+  }
   return velocityBase;
 }
 


### PR DESCRIPTION
## Summary
- Persist velocity base in local storage and reload stored value
- Add unit test ensuring velocity base persists across sessions
- Update task list with new export/import subtasks

## Testing
- `for f in test_*.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_68a9d9606afc8333b81ae684337727a5