### PR TITLE
Fix developer controls visibility and export velocity base

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -74,5 +74,6 @@
 73. [x] Crear pruebas unitarias para la definición de la velocidad base.
 74. [x] Persistir la velocidad base en la configuración local.
 75. [x] Crear pruebas unitarias para la persistencia de la velocidad base.
-76. [ ] Incluir la velocidad base en la exportación e importación de configuraciones.
-77. [ ] Crear pruebas unitarias para la exportación e importación de la velocidad base.
+76. [x] Incluir la velocidad base en la exportación e importación de configuraciones.
+77. [x] Crear pruebas unitarias para la exportación e importación de la velocidad base.
+78. [x] Asegurar que los controles del modo desarrollador permanezcan visibles tras reconstruir el panel de familias.

--- a/script.js
+++ b/script.js
@@ -89,7 +89,16 @@ if (typeof document !== 'undefined') {
     let velocityBase = getVelocityBase();
 
     if (developerBtn && developerControls) {
-      initDeveloperMode({ button: developerBtn, panel: developerControls });
+      const devMode = initDeveloperMode({
+        button: developerBtn,
+        panel: developerControls,
+      });
+
+      developerBtn.addEventListener('click', () => {
+        if (devMode.isActive()) {
+          familyPanel.classList.add('active');
+        }
+      });
 
       // Control para ajustar la velocidad base de referencia
       const velLabel = document.createElement('label');
@@ -149,7 +158,9 @@ if (typeof document !== 'undefined') {
     }
 
     function buildFamilyPanel() {
+      const devControls = document.getElementById('developer-controls');
       familyPanel.innerHTML = '';
+      if (devControls) familyPanel.appendChild(devControls);
 
       const bgItem = document.createElement('div');
       bgItem.className = 'family-config-item';
@@ -781,6 +792,7 @@ function exportConfiguration() {
     assignedFamilies,
     familyCustomizations,
     enabledInstruments,
+    velocityBase: getVelocityBase(),
   });
 }
 
@@ -789,6 +801,9 @@ function importConfiguration(json, tracks = []) {
   assignedFamilies = data.assignedFamilies || {};
   familyCustomizations = data.familyCustomizations || {};
   Object.assign(enabledInstruments, data.enabledInstruments || {});
+  if (typeof data.velocityBase === 'number') {
+    setVelocityBase(data.velocityBase);
+  }
 
   Object.keys(FAMILY_DEFAULTS).forEach((fam) => {
     FAMILY_PRESETS[fam] = { ...FAMILY_DEFAULTS[fam] };

--- a/test_config_export_import.js
+++ b/test_config_export_import.js
@@ -5,6 +5,7 @@ const {
   importConfiguration,
   INSTRUMENT_COLOR_SHIFT,
   adjustColorBrightness,
+  getVelocityBase,
 } = require('./script.js');
 
 const tracks = assignTrackInfo([{ name: 'Flauta', events: [] }]);
@@ -13,6 +14,7 @@ const config = {
   assignedFamilies: { Flauta: 'Metales' },
   familyCustomizations: { Metales: { color: '#123456', shape: 'triangle' } },
   enabledInstruments: { Flauta: true },
+  velocityBase: 80,
 };
 
 importConfiguration(config, tracks);
@@ -24,6 +26,8 @@ const expectedColor = adjustColorBrightness(
   INSTRUMENT_COLOR_SHIFT['Flauta']
 );
 assert.strictEqual(tracks[0].color, expectedColor);
+
+assert.strictEqual(getVelocityBase(), 80);
 
 const exported = JSON.parse(exportConfiguration());
 assert.deepStrictEqual(exported, config);


### PR DESCRIPTION
## Summary
- Preserve developer-mode controls when rebuilding the family panel and open the panel when developer mode activates
- Include velocity base in configuration export/import and cover with tests
- Update incremental plan with completed tasks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9db14266883339dc4f365b3006c0b