### PR TITLE
feat: add developer controls for visual effects

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -61,19 +61,21 @@
 60. [x] Corregir la figura triángulo y triángulo alargado para que tengan su punto de alineación en su esquina izquierda.
 61. [x] Crear el botón "Modo desarrollador" que habilite opciones avanzadas en el panel inferior.
 62. [ ] Permitir definir rangos de tono de color para las familias, eligiendo el color más brillante y el más oscuro para calcular matices intermedios.
-63. [ ] Agregar controles con porcentajes que modifiquen la escala de opacidad en los diferentes puntos del canvas.
-64. [ ] Agregar un control porcentual para manejar el tamaño, la difuminación y la duración del glow.
-65. [ ] Agregar un control porcentual para manejar la cantidad de bump y el tiempo de regreso al tamaño normal.
+63. [x] Agregar controles con porcentajes que modifiquen la escala de opacidad en los diferentes puntos del canvas.
+64. [x] Agregar un control porcentual para manejar el tamaño, la difuminación y la duración del glow.
+65. [x] Agregar un control porcentual para manejar la cantidad de bump y el tiempo de regreso al tamaño normal.
 66. [x] Agregar un control para definir la velocidad base donde 67 (número editable) represente el 100%.
 67. [x] Crear pruebas unitarias para la variación de altura basada en velocidad MIDI.
 68. [x] Crear pruebas unitarias para el reconocimiento de tildes en los nombres de los instrumentos.
 69. [ ] Crear pruebas unitarias para los rangos de tono de color por familia.
-70. [ ] Crear pruebas unitarias para la escala de opacidad configurable.
-71. [ ] Crear pruebas unitarias para el control de tamaño, difuminación y duración del glow.
-72. [ ] Crear pruebas unitarias para el control de cantidad y duración del bump.
+70. [x] Crear pruebas unitarias para la escala de opacidad configurable.
+71. [x] Crear pruebas unitarias para el control de tamaño, difuminación y duración del glow.
+72. [x] Crear pruebas unitarias para el control de cantidad y duración del bump.
 73. [x] Crear pruebas unitarias para la definición de la velocidad base.
 74. [x] Persistir la velocidad base en la configuración local.
 75. [x] Crear pruebas unitarias para la persistencia de la velocidad base.
 76. [x] Incluir la velocidad base en la exportación e importación de configuraciones.
 77. [x] Crear pruebas unitarias para la exportación e importación de la velocidad base.
 78. [x] Asegurar que los controles del modo desarrollador permanezcan visibles tras reconstruir el panel de familias.
+79. [ ] Incluir los parámetros de opacidad, glow y bump en la exportación e importación de configuraciones.
+80. [ ] Crear pruebas unitarias para la exportación e importación de los parámetros de opacidad, glow y bump.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js && node test_audio_player.js && node test_offscreen_render.js && node test_instrument_toggle.js && node test_tempo_map.js && node test_fixed_fps.js && node test_instrument_persistence.js && node test_velocity_height.js && node test_instrument_accents.js && node test_developer_mode.js && node test_velocity_base.js"
+    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js && node test_audio_player.js && node test_offscreen_render.js && node test_instrument_toggle.js && node test_tempo_map.js && node test_fixed_fps.js && node test_instrument_persistence.js && node test_velocity_height.js && node test_instrument_accents.js && node test_developer_mode.js && node test_velocity_base.js && node test_opacity_scale.js && node test_glow_control.js && node test_bump_control.js"
   },
   "keywords": [],
   "author": "",

--- a/script.js
+++ b/script.js
@@ -20,6 +20,12 @@ const {
   computeVelocityHeight,
   setVelocityBase,
   getVelocityBase,
+  setOpacityScale,
+  getOpacityScale,
+  setGlowStrength,
+  getGlowStrength,
+  setBumpControl,
+  getBumpControl,
   preprocessTempoMap,
   ticksToSeconds,
 } = typeof require !== 'undefined' ? require('./utils.js') : window.utils;
@@ -117,6 +123,66 @@ if (typeof document !== 'undefined') {
       });
       developerControls.appendChild(velLabel);
       developerControls.appendChild(velInput);
+
+      // Control para la escala de opacidad
+      const { edge, mid } = getOpacityScale();
+      const edgeLabel = document.createElement('label');
+      edgeLabel.textContent = 'Opacidad extremos (%):';
+      const edgeInput = document.createElement('input');
+      edgeInput.type = 'number';
+      edgeInput.min = '0';
+      edgeInput.max = '100';
+      edgeInput.value = Math.round(edge * 100);
+      const midLabel = document.createElement('label');
+      midLabel.textContent = 'Opacidad centro (%):';
+      const midInput = document.createElement('input');
+      midInput.type = 'number';
+      midInput.min = '0';
+      midInput.max = '100';
+      midInput.value = Math.round(mid * 100);
+      const updateOpacityScale = () => {
+        const e = parseFloat(edgeInput.value) / 100;
+        const m = parseFloat(midInput.value) / 100;
+        if (!isNaN(e) && !isNaN(m) && m >= e && m <= 1) {
+          setOpacityScale(e, m);
+        }
+      };
+      edgeInput.addEventListener('change', updateOpacityScale);
+      midInput.addEventListener('change', updateOpacityScale);
+      developerControls.appendChild(edgeLabel);
+      developerControls.appendChild(edgeInput);
+      developerControls.appendChild(midLabel);
+      developerControls.appendChild(midInput);
+
+      // Control para el glow
+      const glowLabel = document.createElement('label');
+      glowLabel.textContent = 'Glow (%):';
+      const glowInput = document.createElement('input');
+      glowInput.type = 'number';
+      glowInput.min = '0';
+      glowInput.max = '300';
+      glowInput.value = Math.round(getGlowStrength() * 100);
+      glowInput.addEventListener('change', () => {
+        const val = parseInt(glowInput.value, 10);
+        if (!isNaN(val)) setGlowStrength(Math.max(0, val) / 100);
+      });
+      developerControls.appendChild(glowLabel);
+      developerControls.appendChild(glowInput);
+
+      // Control para el bump
+      const bumpLabel = document.createElement('label');
+      bumpLabel.textContent = 'Bump (%):';
+      const bumpInput = document.createElement('input');
+      bumpInput.type = 'number';
+      bumpInput.min = '0';
+      bumpInput.max = '300';
+      bumpInput.value = Math.round(getBumpControl() * 100);
+      bumpInput.addEventListener('change', () => {
+        const val = parseInt(bumpInput.value, 10);
+        if (!isNaN(val)) setBumpControl(Math.max(0, val) / 100);
+      });
+      developerControls.appendChild(bumpLabel);
+      developerControls.appendChild(bumpInput);
     }
 
     let currentTracks = [];
@@ -1054,6 +1120,12 @@ if (typeof module !== 'undefined') {
       computeVelocityHeight,
       setVelocityBase,
       getVelocityBase,
+      setOpacityScale,
+      getOpacityScale,
+      setGlowStrength,
+      getGlowStrength,
+      setBumpControl,
+      getBumpControl,
       preprocessTempoMap,
       ticksToSeconds,
       setFamilyCustomization,

--- a/test_bump_control.js
+++ b/test_bump_control.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const { setBumpControl, computeBumpHeight } = require('./script');
+
+function approx(a, b, eps = 1e-6) {
+  assert(Math.abs(a - b) < eps, `${a} != ${b}`);
+}
+
+const base = 10;
+setBumpControl(2);
+approx(computeBumpHeight(base, 0, 0, 1), 20);
+approx(computeBumpHeight(base, 1, 0, 1), 15);
+approx(computeBumpHeight(base, 2, 0, 1), base);
+
+console.log('Pruebas de control de bump completadas');

--- a/test_glow_control.js
+++ b/test_glow_control.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+const { setGlowStrength, computeGlowAlpha, applyGlowEffect } = require('./script');
+
+function approx(a, b, eps = 1e-6) {
+  assert(Math.abs(a - b) < eps, `${a} != ${b}`);
+}
+
+setGlowStrength(2);
+approx(computeGlowAlpha(0.2, 0), 0.5);
+
+const ctx = {
+  shadowBlur: 0,
+  shadowColor: null,
+  fillStyle: null,
+  save() {},
+  restore() {},
+  beginPath() {},
+  rect(x, y, w, h) {
+    this.w = w;
+    this.h = h;
+  },
+  fill() {},
+};
+
+applyGlowEffect(ctx, 'square', 0, 0, 10, 10, 0.5);
+assert(ctx.shadowBlur > 20, 'blur no escalado');
+assert(ctx.w > 10 && ctx.h > 10, 'tamaño no escalado');
+
+console.log('Pruebas de control de glow completadas');

--- a/test_opacity_scale.js
+++ b/test_opacity_scale.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+const { setOpacityScale, getOpacityScale, computeOpacity } = require('./script');
+
+function approx(a, b, eps = 1e-6) {
+  assert(Math.abs(a - b) < eps, `${a} != ${b}`);
+}
+
+setOpacityScale(0.1, 0.8);
+const scale = getOpacityScale();
+approx(scale.edge, 0.1);
+approx(scale.mid, 0.8);
+
+approx(computeOpacity(-50, 50, 600), 0.1);
+approx(computeOpacity(125, 175, 600), 0.45);
+
+console.log('Pruebas de escala de opacidad configurables completadas');


### PR DESCRIPTION
## Summary
- allow customizing opacity scale, glow strength and bump factor
- expose new developer controls and persist settings
- add unit tests for opacity, glow and bump controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9dcc738948333a4bf8942c73e08c5