### PR TITLE
Include developer parameters in configuration export

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -77,5 +77,7 @@
 76. [x] Incluir la velocidad base en la exportación e importación de configuraciones.
 77. [x] Crear pruebas unitarias para la exportación e importación de la velocidad base.
 78. [x] Asegurar que los controles del modo desarrollador permanezcan visibles tras reconstruir el panel de familias.
-79. [ ] Incluir los parámetros de opacidad, glow y bump en la exportación e importación de configuraciones.
-80. [ ] Crear pruebas unitarias para la exportación e importación de los parámetros de opacidad, glow y bump.
+79. [x] Incluir los parámetros de opacidad, glow y bump en la exportación e importación de configuraciones.
+80. [x] Crear pruebas unitarias para la exportación e importación de los parámetros de opacidad, glow y bump.
+81. [ ] Incluir los rangos de tono de color por familia en la exportación e importación de configuraciones.
+82. [ ] Crear pruebas unitarias para la exportación e importación de los rangos de tono de color por familia.

--- a/script.js
+++ b/script.js
@@ -859,6 +859,9 @@ function exportConfiguration() {
     familyCustomizations,
     enabledInstruments,
     velocityBase: getVelocityBase(),
+    opacityScale: getOpacityScale(),
+    glowStrength: getGlowStrength(),
+    bumpControl: getBumpControl(),
   });
 }
 
@@ -869,6 +872,19 @@ function importConfiguration(json, tracks = []) {
   Object.assign(enabledInstruments, data.enabledInstruments || {});
   if (typeof data.velocityBase === 'number') {
     setVelocityBase(data.velocityBase);
+  }
+  if (
+    data.opacityScale &&
+    typeof data.opacityScale.edge === 'number' &&
+    typeof data.opacityScale.mid === 'number'
+  ) {
+    setOpacityScale(data.opacityScale.edge, data.opacityScale.mid);
+  }
+  if (typeof data.glowStrength === 'number') {
+    setGlowStrength(data.glowStrength);
+  }
+  if (typeof data.bumpControl === 'number') {
+    setBumpControl(data.bumpControl);
   }
 
   Object.keys(FAMILY_DEFAULTS).forEach((fam) => {

--- a/test_config_export_import.js
+++ b/test_config_export_import.js
@@ -6,6 +6,9 @@ const {
   INSTRUMENT_COLOR_SHIFT,
   adjustColorBrightness,
   getVelocityBase,
+  getOpacityScale,
+  getGlowStrength,
+  getBumpControl,
 } = require('./script.js');
 
 const tracks = assignTrackInfo([{ name: 'Flauta', events: [] }]);
@@ -15,6 +18,9 @@ const config = {
   familyCustomizations: { Metales: { color: '#123456', shape: 'triangle' } },
   enabledInstruments: { Flauta: true },
   velocityBase: 80,
+  opacityScale: { edge: 0.1, mid: 0.8 },
+  glowStrength: 1.5,
+  bumpControl: 1.2,
 };
 
 importConfiguration(config, tracks);
@@ -28,6 +34,9 @@ const expectedColor = adjustColorBrightness(
 assert.strictEqual(tracks[0].color, expectedColor);
 
 assert.strictEqual(getVelocityBase(), 80);
+assert.deepStrictEqual(getOpacityScale(), { edge: 0.1, mid: 0.8 });
+assert.strictEqual(getGlowStrength(), 1.5);
+assert.strictEqual(getBumpControl(), 1.2);
 
 const exported = JSON.parse(exportConfiguration());
 assert.deepStrictEqual(exported, config);


### PR DESCRIPTION
## Summary
- Export and import opacity, glow, and bump parameters alongside existing configuration values
- Add unit tests for exporting and importing developer parameters
- Update tasks list for completed work and future color range export tasks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9df860f6c833396199805f27e4318