### PR TITLE
Add color tone range customization and tests

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -60,14 +60,14 @@
 59. [x] Corregir el reconocimiento de tildes en los nombres de los instrumentos.
 60. [x] Corregir la figura triángulo y triángulo alargado para que tengan su punto de alineación en su esquina izquierda.
 61. [x] Crear el botón "Modo desarrollador" que habilite opciones avanzadas en el panel inferior.
-62. [ ] Permitir definir rangos de tono de color para las familias, eligiendo el color más brillante y el más oscuro para calcular matices intermedios.
+62. [x] Permitir definir rangos de tono de color para las familias, eligiendo el color más brillante y el más oscuro para calcular matices intermedios.
 63. [x] Agregar controles con porcentajes que modifiquen la escala de opacidad en los diferentes puntos del canvas.
 64. [x] Agregar un control porcentual para manejar el tamaño, la difuminación y la duración del glow.
 65. [x] Agregar un control porcentual para manejar la cantidad de bump y el tiempo de regreso al tamaño normal.
 66. [x] Agregar un control para definir la velocidad base donde 67 (número editable) represente el 100%.
 67. [x] Crear pruebas unitarias para la variación de altura basada en velocidad MIDI.
 68. [x] Crear pruebas unitarias para el reconocimiento de tildes en los nombres de los instrumentos.
-69. [ ] Crear pruebas unitarias para los rangos de tono de color por familia.
+69. [x] Crear pruebas unitarias para los rangos de tono de color por familia.
 70. [x] Crear pruebas unitarias para la escala de opacidad configurable.
 71. [x] Crear pruebas unitarias para el control de tamaño, difuminación y duración del glow.
 72. [x] Crear pruebas unitarias para el control de cantidad y duración del bump.
@@ -79,5 +79,6 @@
 78. [x] Asegurar que los controles del modo desarrollador permanezcan visibles tras reconstruir el panel de familias.
 79. [x] Incluir los parámetros de opacidad, glow y bump en la exportación e importación de configuraciones.
 80. [x] Crear pruebas unitarias para la exportación e importación de los parámetros de opacidad, glow y bump.
-81. [ ] Incluir los rangos de tono de color por familia en la exportación e importación de configuraciones.
-82. [ ] Crear pruebas unitarias para la exportación e importación de los rangos de tono de color por familia.
+81. [x] Incluir los rangos de tono de color por familia en la exportación e importación de configuraciones.
+82. [x] Crear pruebas unitarias para la exportación e importación de los rangos de tono de color por familia.
+83. [ ] Validar que los rangos de tono de color tengan contraste adecuado y que el color brillante sea más claro que el oscuro.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js && node test_audio_player.js && node test_offscreen_render.js && node test_instrument_toggle.js && node test_tempo_map.js && node test_fixed_fps.js && node test_instrument_persistence.js && node test_velocity_height.js && node test_instrument_accents.js && node test_developer_mode.js && node test_velocity_base.js && node test_opacity_scale.js && node test_glow_control.js && node test_bump_control.js"
+    "test": "node test_parsers.js && node test_visual_effects.js && node test_playback_controls.js && node test_color_variations.js && node test_shapes.js && node test_family_modifiers.js && node test_aspect_ratio.js && node test_family_customization.js && node test_config_export_import.js && node test_ui_integration.js && node test_canvas_color.js && node test_audio_player.js && node test_offscreen_render.js && node test_instrument_toggle.js && node test_tempo_map.js && node test_fixed_fps.js && node test_instrument_persistence.js && node test_velocity_height.js && node test_instrument_accents.js && node test_developer_mode.js && node test_velocity_base.js && node test_opacity_scale.js && node test_glow_control.js && node test_bump_control.js && node test_family_color_range.js && node test_color_range_export_import.js"
   },
   "keywords": [],
   "author": "",

--- a/test_color_range_export_import.js
+++ b/test_color_range_export_import.js
@@ -1,0 +1,42 @@
+const assert = require('assert');
+const {
+  assignTrackInfo,
+  setFamilyCustomization,
+  exportConfiguration,
+  importConfiguration,
+  FAMILY_PRESETS,
+  INSTRUMENT_COLOR_SHIFT,
+  resetFamilyCustomizations,
+} = require('./script.js');
+const { interpolateColor } = require('./utils.js');
+
+resetFamilyCustomizations();
+
+const tracks = assignTrackInfo([{ name: 'Flauta', events: [] }]);
+setFamilyCustomization(
+  'Maderas de timbre "redondo"',
+  { colorBright: '#0000ff', colorDark: '#000044' },
+  tracks,
+);
+
+const exported = exportConfiguration();
+const parsed = JSON.parse(exported);
+assert.strictEqual(
+  parsed.familyCustomizations['Maderas de timbre "redondo"'].colorBright,
+  '#0000ff',
+);
+assert.strictEqual(
+  parsed.familyCustomizations['Maderas de timbre "redondo"'].colorDark,
+  '#000044',
+);
+
+resetFamilyCustomizations();
+
+const newTracks = assignTrackInfo([{ name: 'Flauta', events: [] }]);
+importConfiguration(exported, newTracks);
+
+const factor = (INSTRUMENT_COLOR_SHIFT['Flauta'] + 1) / 2;
+const expectedColor = interpolateColor('#000044', '#0000ff', factor);
+assert.strictEqual(newTracks[0].color, expectedColor);
+
+console.log('Pruebas de exportación e importación de rangos de color completadas');

--- a/test_family_color_range.js
+++ b/test_family_color_range.js
@@ -1,0 +1,38 @@
+const assert = require('assert');
+const {
+  assignTrackInfo,
+  setFamilyCustomization,
+  INSTRUMENT_COLOR_SHIFT,
+  resetFamilyCustomizations,
+} = require('./script.js');
+const { interpolateColor } = require('./utils.js');
+
+resetFamilyCustomizations();
+
+const tracks = assignTrackInfo([
+  { name: 'Oboe', events: [] },
+  { name: 'Clarinete', events: [] },
+]);
+
+setFamilyCustomization(
+  'Dobles cañas',
+  { colorBright: '#0000ff', colorDark: '#000044' },
+  tracks,
+);
+
+const bright = '#0000ff';
+const dark = '#000044';
+
+const oboe = tracks.find((t) => t.instrument === 'Oboe');
+const clarinete = tracks.find((t) => t.instrument === 'Clarinete');
+
+const factorOboe = (INSTRUMENT_COLOR_SHIFT['Oboe'] + 1) / 2;
+const factorClarinete = (INSTRUMENT_COLOR_SHIFT['Clarinete'] + 1) / 2;
+
+const expectedOboe = interpolateColor(dark, bright, factorOboe);
+const expectedClarinete = interpolateColor(dark, bright, factorClarinete);
+
+assert.strictEqual(oboe.color, expectedOboe);
+assert.strictEqual(clarinete.color, expectedClarinete);
+
+console.log('Pruebas de rangos de color por familia completadas');

--- a/utils.js
+++ b/utils.js
@@ -27,6 +27,24 @@ function adjustColorBrightness(color, factor) {
   return result;
 }
 
+// Interpola entre dos colores hexadecimales según un factor [0,1]
+function interpolateColor(color1, color2, factor) {
+  const c1 = parseInt(color1.slice(1), 16);
+  const c2 = parseInt(color2.slice(1), 16);
+  const r1 = (c1 >> 16) & 0xff;
+  const g1 = (c1 >> 8) & 0xff;
+  const b1 = c1 & 0xff;
+  const r2 = (c2 >> 16) & 0xff;
+  const g2 = (c2 >> 8) & 0xff;
+  const b2 = c2 & 0xff;
+  const r = Math.round(r1 + (r2 - r1) * factor);
+  const g = Math.round(g1 + (g2 - g1) * factor);
+  const b = Math.round(b1 + (b2 - b1) * factor);
+  return `#${r.toString(16).padStart(2, '0')}${g
+    .toString(16)
+    .padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+}
+
 // Parámetros configurables de opacidad
 let opacityScale = { edge: 0.05, mid: 0.7 };
 
@@ -386,6 +404,7 @@ const utils = {
   applyGlowEffect,
   drawNoteShape,
   adjustColorBrightness,
+  interpolateColor,
   computeVelocityHeight,
   setVelocityBase,
   getVelocityBase,


### PR DESCRIPTION
## Summary
- Allow families to define bright and dark colors and interpolate shades per instrument
- Support exporting and importing family color ranges
- Add unit tests for color range interpolation and configuration persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9e0de1e00833399a76ee288cfcd73