### PR TITLE
Apply developer color ranges to instrument notes

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -82,3 +82,4 @@
 81. [x] Incluir los rangos de tono de color por familia en la exportación e importación de configuraciones.
 82. [x] Crear pruebas unitarias para la exportación e importación de los rangos de tono de color por familia.
 83. [ ] Validar que los rangos de tono de color tengan contraste adecuado y que el color brillante sea más claro que el oscuro.
+84. [x] Corregir la aplicación del rango de colores del modo desarrollador a las familias de instrumentos.

--- a/script.js
+++ b/script.js
@@ -311,6 +311,7 @@ if (typeof document !== 'undefined') {
             family,
             { colorBright: brightInput.value },
             currentTracks,
+            notes,
           );
         });
         darkInput.addEventListener('change', () => {
@@ -318,10 +319,16 @@ if (typeof document !== 'undefined') {
             family,
             { colorDark: darkInput.value },
             currentTracks,
+            notes,
           );
         });
         shapeSelect.addEventListener('change', () => {
-          setFamilyCustomization(family, { shape: shapeSelect.value }, currentTracks);
+          setFamilyCustomization(
+            family,
+            { shape: shapeSelect.value },
+            currentTracks,
+            notes,
+          );
         });
 
         item.appendChild(label);
@@ -335,7 +342,7 @@ if (typeof document !== 'undefined') {
       resetBtn.id = 'reset-family-defaults';
       resetBtn.textContent = 'Restablecer predeterminados';
       resetBtn.addEventListener('click', () => {
-        resetFamilyCustomizations(currentTracks);
+        resetFamilyCustomizations(currentTracks, notes);
         buildFamilyPanel();
       });
       familyPanel.appendChild(resetBtn);
@@ -864,7 +871,8 @@ function saveFamilyCustomizations() {
 function setFamilyCustomization(
   family,
   { color, shape, colorBright, colorDark },
-  tracks = []
+  tracks = [],
+  notes = []
 ) {
   const preset = FAMILY_PRESETS[family] || { shape: 'square', color: '#ffffff' };
   if (color) {
@@ -891,9 +899,15 @@ function setFamilyCustomization(
       t.color = getInstrumentColor(preset, t.instrument);
     }
   });
+  notes.forEach((n) => {
+    if (n.family === family) {
+      n.shape = preset.shape;
+      n.color = getInstrumentColor(preset, n.instrument);
+    }
+  });
 }
 
-function resetFamilyCustomizations(tracks = []) {
+function resetFamilyCustomizations(tracks = [], notes = []) {
   Object.keys(FAMILY_DEFAULTS).forEach((fam) => {
     FAMILY_PRESETS[fam] = { ...FAMILY_DEFAULTS[fam] };
   });
@@ -905,6 +919,11 @@ function resetFamilyCustomizations(tracks = []) {
     const preset = FAMILY_PRESETS[t.family] || { shape: 'square', color: '#ffffff' };
     t.shape = preset.shape;
     t.color = getInstrumentColor(preset, t.instrument);
+  });
+  notes.forEach((n) => {
+    const preset = FAMILY_PRESETS[n.family] || { shape: 'square', color: '#ffffff' };
+    n.shape = preset.shape;
+    n.color = getInstrumentColor(preset, n.instrument);
   });
 }
 

--- a/test_family_color_range.js
+++ b/test_family_color_range.js
@@ -13,11 +13,18 @@ const tracks = assignTrackInfo([
   { name: 'Oboe', events: [] },
   { name: 'Clarinete', events: [] },
 ]);
+const notes = tracks.map((t) => ({
+  instrument: t.instrument,
+  family: t.family,
+  color: t.color,
+  shape: t.shape,
+}));
 
 setFamilyCustomization(
   'Dobles cañas',
   { colorBright: '#0000ff', colorDark: '#000044' },
   tracks,
+  notes,
 );
 
 const bright = '#0000ff';
@@ -34,5 +41,11 @@ const expectedClarinete = interpolateColor(dark, bright, factorClarinete);
 
 assert.strictEqual(oboe.color, expectedOboe);
 assert.strictEqual(clarinete.color, expectedClarinete);
+
+const noteOboe = notes.find((n) => n.instrument === 'Oboe');
+const noteClarinete = notes.find((n) => n.instrument === 'Clarinete');
+
+assert.strictEqual(noteOboe.color, expectedOboe);
+assert.strictEqual(noteClarinete.color, expectedClarinete);
 
 console.log('Pruebas de rangos de color por familia completadas');


### PR DESCRIPTION
## Summary
- propagate developer color range changes to instrument notes
- update family customization reset to refresh note colors
- test color range updates for existing notes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9e57ded2083339a4433dd010f4a1f