### PR TITLE
Align triangle note width with velocity-scaled bump

### DIFF
--- a/agents_tareas
+++ b/agents_tareas
@@ -83,3 +83,5 @@
 82. [x] Crear pruebas unitarias para la exportación e importación de los rangos de tono de color por familia.
 83. [ ] Validar que los rangos de tono de color tengan contraste adecuado y que el color brillante sea más claro que el oscuro.
 84. [x] Corregir la aplicación del rango de colores del modo desarrollador a las familias de instrumentos.
+85. [x] Corregir el triángulo alargado para que su base se alinee con NOTE ON y NOTE OFF.
+86. [x] Asegurar que la velocidad base escale proporcionalmente la altura y el bump de las figuras.

--- a/test_shapes.js
+++ b/test_shapes.js
@@ -59,7 +59,7 @@ shapes.forEach(([shape, expected]) => {
   assert(ctx.fillCalled, 'fill no llamado');
 });
 
-// Verificación de triángulo equilátero con vértice superior centrado
+// Verificación de vértice centrado y extremos alineados con NOTE ON/OFF
 const triCtx = {
   path: [],
   beginPath() {},
@@ -75,15 +75,12 @@ const triCtx = {
 drawNoteShape(triCtx, 'triangle', 0, 0, 10, 10);
 assert.strictEqual(triCtx.path.length, 3, 'triángulo con puntos incorrectos');
 const [top, right, left] = triCtx.path;
-const dist = (a, b) => Math.hypot(a[0] - b[0], a[1] - b[1]);
-const a = dist(top, right);
-const b = dist(right, left);
-const c = dist(left, top);
 const tol = 1e-6;
-assert(Math.abs(a - b) < tol && Math.abs(b - c) < tol, 'lados no iguales');
-assert(Math.abs(top[0] - 5) < tol, 'vértice superior no centrado');
+assert(Math.abs(top[0] - 5) < tol && Math.abs(top[1]) < tol, 'vértice superior no centrado');
+assert(Math.abs(right[0] - 10) < tol && Math.abs(right[1] - 10) < tol, 'extremo derecho mal posicionado');
+assert(Math.abs(left[0]) < tol && Math.abs(left[1] - 10) < tol, 'extremo izquierdo mal posicionado');
 
-// Verificación de alineación a la izquierda para triángulo alargado
+// Verificación de alineación izquierda/derecha para triángulo alargado
 const triCtxWide = {
   path: [],
   beginPath() {},
@@ -97,7 +94,10 @@ const triCtxWide = {
   fill() {},
 };
 drawNoteShape(triCtxWide, 'triangle', 0, 0, 20, 10);
-const minX = Math.min(...triCtxWide.path.map((p) => p[0]));
+const xs = triCtxWide.path.map((p) => p[0]);
+const minX = Math.min(...xs);
+const maxX = Math.max(...xs);
 assert.strictEqual(minX, 0, 'triángulo alargado no alineado a la izquierda');
+assert.strictEqual(maxX, 20, 'triángulo alargado no alineado a la derecha');
 
 console.log('Pruebas de figuras geométricas completadas');

--- a/test_velocity_height.js
+++ b/test_velocity_height.js
@@ -1,9 +1,14 @@
 const assert = require('assert');
-const { computeVelocityHeight } = require('./script');
+const { computeVelocityHeight, computeBumpHeight } = require('./script');
 
 const base = 10;
 assert.strictEqual(computeVelocityHeight(base, 67), base);
 assert.strictEqual(computeVelocityHeight(base, 134), base * 2);
 assert(Math.abs(computeVelocityHeight(base, 33) - base * (33 / 67)) < 1e-6);
+
+// Verifica que la altura del bump también escala con la velocidad
+const bumpBase = computeBumpHeight(computeVelocityHeight(base, 67), 0, 0, 1);
+const bumpDouble = computeBumpHeight(computeVelocityHeight(base, 134), 0, 0, 1);
+assert.strictEqual(bumpDouble, bumpBase * 2);
 
 console.log('Pruebas de altura por velocidad completadas');

--- a/utils.js
+++ b/utils.js
@@ -225,12 +225,9 @@ function drawNoteShape(ctx, shape, x, y, width, height, stroke = false) {
       break;
     }
     case 'triangle': {
-      const side = Math.min(width, (2 / Math.sqrt(3)) * height);
-      const h = (Math.sqrt(3) / 2) * side;
-      const offsetY = y + (height - h);
-      ctx.moveTo(x + side / 2, offsetY);
-      ctx.lineTo(x + side, offsetY + h);
-      ctx.lineTo(x, offsetY + h);
+      ctx.moveTo(x + width / 2, y);
+      ctx.lineTo(x + width, y + height);
+      ctx.lineTo(x, y + height);
       ctx.closePath();
       break;
     }


### PR DESCRIPTION
## Summary
- Draw elongated triangle so its base spans from NOTE ON to NOTE OFF
- Ensure bump height scales with velocity and add tests
- Document completed tasks in agents_tareas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9e84a23a4833397c0de36ab03a662