### PR TITLE
Replace elongated triangle with diamond and hide cursor in fullscreen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Figuras geométricas a emplear:
 1.	Ovalos alargados (del note on al off).
 2.	Cápsulas alargadas (rectángulos con bordes redondeados).
 3.	Estrellas alargadas (de 4 puntas y con lados cóncavos).
-4.	Triángulos alargados (con uno de los ángulos al centro entre el note on y el off).
+4.	Diamantes alargados con lados rectos (alineados entre el note on y el note off).
 5.	Círculos SIN alargamiento (para dibujarla solo se toman en cuenta la altura del grid y el note ON, no el note off).
 6.	Cuadrados SIN alargamiento.
 7.	Triángulos invertidos SIN alargamiento.
@@ -59,7 +59,7 @@ Figuras y colores de las familias:
 8.	Platillos: círculos sin alargamiento, grises con tamaño + 30%.
 9.	Placas: cuadrados sin alargamiento rojos.
 10.	Auxiliares: círculos sin alargamiento morado oscuro con bump + 30%.
-11.	Cuerdas frotadas: triángulos alargados naranja.
+11.	Cuerdas frotadas: diamantes alargados naranjas.
 12.	Cuerdas pulsadas: estrellas de 4 puntas sin alargamiento verdes.
 13.	Voces: cápsulas alargadas grises.
 

--- a/agents_tareas
+++ b/agents_tareas
@@ -91,6 +91,9 @@
 90. [x] Implementar acciones que mejoren la fluidez de la animación, manteniendo 60 fps fijos sin retrasos por bump o glow.
 91. [x] Agregar un título: “Visualizador MIDI - Jaime Jaramillo Arias”.
 92. [x] Ajustar la detección de silencio del audio para que la visualización del MIDI comience exactamente con la señal de audio.
-93. [ ] Mejorar en general la apariencia de la UI para que se vea más profesional.
+93. [x] Mejorar en general la apariencia de la UI para que se vea más profesional.
 94. [x] Crear pruebas unitarias para asegurar que la altura de las notas renderizadas se adapte según la velocidad MIDI.
 95. [x] Crear pruebas unitarias para la detección precisa de silencio en archivos WAV.
+96. [x] Cambiar la figura triángulo alargado por un diamante alargado con lados rectos.
+97. [x] Ocultar el puntero del mouse al activar el modo de pantalla completa.
+98. [x] Actualizar las pruebas unitarias para el diamante alargado.

--- a/script.js
+++ b/script.js
@@ -533,7 +533,9 @@ if (typeof document !== 'undefined') {
     applyCanvasSize(false);
 
     document.addEventListener('fullscreenchange', () => {
-      applyCanvasSize();
+      const fs = !!document.fullscreenElement;
+      applyCanvasSize(fs);
+      canvas.style.cursor = fs ? 'none' : 'default';
     });
 
     function startPlayback() {
@@ -643,8 +645,10 @@ if (typeof document !== 'undefined') {
       onFullScreen: () => {
         if (!document.fullscreenElement) {
           canvas.requestFullscreen();
+          canvas.style.cursor = 'none';
         } else {
           document.exitFullscreen();
+          canvas.style.cursor = 'default';
         }
       },
     });
@@ -777,7 +781,7 @@ const FAMILY_DEFAULTS = {
   Platillos: { shape: 'circle', color: '#808080' },
   Placas: { shape: 'square', color: '#ff0000' },
   Auxiliares: { shape: 'circle', color: '#4b0082' },
-  'Cuerdas frotadas': { shape: 'triangle', color: '#ffa500' },
+  'Cuerdas frotadas': { shape: 'diamond', color: '#ffa500' },
   'Cuerdas pulsadas': { shape: 'star4', color: '#008000' },
   Voces: { shape: 'capsule', color: '#808080' },
 };

--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,26 @@ body {
   display: flex;
   gap: 10px;
   margin: 10px;
+  background: #1a1a1a;
+  padding: 10px;
+  border-radius: 6px;
+}
+
+button,
+select {
+  background: #333;
+  border: 1px solid #555;
+  color: #fff;
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-size: 1rem;
+  transition: background 0.2s;
+}
+
+button:hover,
+select:hover {
+  background: #444;
+  cursor: pointer;
 }
 
 #family-config-panel {

--- a/test_config_export_import.js
+++ b/test_config_export_import.js
@@ -15,7 +15,7 @@ const tracks = assignTrackInfo([{ name: 'Flauta', events: [] }]);
 
 const config = {
   assignedFamilies: { Flauta: 'Metales' },
-  familyCustomizations: { Metales: { color: '#123456', shape: 'triangle' } },
+  familyCustomizations: { Metales: { color: '#123456', shape: 'diamond' } },
   enabledInstruments: { Flauta: true },
   velocityBase: 80,
   opacityScale: { edge: 0.1, mid: 0.8 },
@@ -26,7 +26,7 @@ const config = {
 importConfiguration(config, tracks);
 
 assert.strictEqual(tracks[0].family, 'Metales');
-assert.strictEqual(tracks[0].shape, 'triangle');
+assert.strictEqual(tracks[0].shape, 'diamond');
 const expectedColor = adjustColorBrightness(
   '#123456',
   INSTRUMENT_COLOR_SHIFT['Flauta']

--- a/test_instrument_persistence.js
+++ b/test_instrument_persistence.js
@@ -12,7 +12,7 @@ let { setInstrumentEnabled, getVisibleNotes } = require('./script');
 
 const notes = [
   { instrument: 'Flauta', start: 0, end: 1, noteNumber: 60, color: '#fff', shape: 'oval', family: 'Maderas de timbre "redondo"', velocity: 67 },
-  { instrument: 'Violin', start: 0, end: 1, noteNumber: 65, color: '#fff', shape: 'triangle', family: 'Cuerdas frotadas', velocity: 67 },
+  { instrument: 'Violin', start: 0, end: 1, noteNumber: 65, color: '#fff', shape: 'diamond', family: 'Cuerdas frotadas', velocity: 67 },
 ];
 
 setInstrumentEnabled('Flauta', false);

--- a/test_instrument_toggle.js
+++ b/test_instrument_toggle.js
@@ -3,7 +3,7 @@ const { getVisibleNotes, setInstrumentEnabled } = require('./script');
 
 const notes = [
   { instrument: 'Flauta', start: 0, end: 1, noteNumber: 60, color: '#fff', shape: 'oval', family: 'Maderas de timbre "redondo"' },
-  { instrument: 'Violin', start: 0, end: 1, noteNumber: 65, color: '#fff', shape: 'triangle', family: 'Cuerdas frotadas' },
+  { instrument: 'Violin', start: 0, end: 1, noteNumber: 65, color: '#fff', shape: 'diamond', family: 'Cuerdas frotadas' },
 ];
 
 setInstrumentEnabled('Flauta', false);

--- a/test_shapes.js
+++ b/test_shapes.js
@@ -45,7 +45,7 @@ const shapes = [
   ['capsule', 'arcCalled'],
   ['circle', 'arcCalled'],
   ['square', 'rectCalled'],
-  ['triangle', 'lineToCalled'],
+  ['diamond', 'lineToCalled'],
   ['star', 'lineToCalled'],
   ['star4', 'lineToCalled'],
   ['pentagon', 'lineToCalled'],
@@ -59,8 +59,8 @@ shapes.forEach(([shape, expected]) => {
   assert(ctx.fillCalled, 'fill no llamado');
 });
 
-// Verificación de vértice centrado y extremos alineados con NOTE ON/OFF
-const triCtx = {
+// Verificación de vértices centrados y extremos alineados con NOTE ON/OFF
+const diaCtx = {
   path: [],
   beginPath() {},
   moveTo(x, y) {
@@ -72,16 +72,17 @@ const triCtx = {
   closePath() {},
   fill() {},
 };
-drawNoteShape(triCtx, 'triangle', 0, 0, 10, 10);
-assert.strictEqual(triCtx.path.length, 3, 'triángulo con puntos incorrectos');
-const [top, right, left] = triCtx.path;
+drawNoteShape(diaCtx, 'diamond', 0, 0, 10, 10);
+assert.strictEqual(diaCtx.path.length, 4, 'diamante con puntos incorrectos');
+const [left, top, right, bottom] = diaCtx.path;
 const tol = 1e-6;
+assert(Math.abs(left[0]) < tol && Math.abs(left[1] - 5) < tol, 'extremo izquierdo mal posicionado');
 assert(Math.abs(top[0] - 5) < tol && Math.abs(top[1]) < tol, 'vértice superior no centrado');
-assert(Math.abs(right[0] - 10) < tol && Math.abs(right[1] - 10) < tol, 'extremo derecho mal posicionado');
-assert(Math.abs(left[0]) < tol && Math.abs(left[1] - 10) < tol, 'extremo izquierdo mal posicionado');
+assert(Math.abs(right[0] - 10) < tol && Math.abs(right[1] - 5) < tol, 'extremo derecho mal posicionado');
+assert(Math.abs(bottom[0] - 5) < tol && Math.abs(bottom[1] - 10) < tol, 'vértice inferior mal posicionado');
 
-// Verificación de alineación izquierda/derecha para triángulo alargado
-const triCtxWide = {
+// Verificación de alineación izquierda/derecha para diamante alargado
+const diaCtxWide = {
   path: [],
   beginPath() {},
   moveTo(x, y) {
@@ -93,11 +94,11 @@ const triCtxWide = {
   closePath() {},
   fill() {},
 };
-drawNoteShape(triCtxWide, 'triangle', 0, 0, 20, 10);
-const xs = triCtxWide.path.map((p) => p[0]);
+drawNoteShape(diaCtxWide, 'diamond', 0, 0, 20, 10);
+const xs = diaCtxWide.path.map((p) => p[0]);
 const minX = Math.min(...xs);
 const maxX = Math.max(...xs);
-assert.strictEqual(minX, 0, 'triángulo alargado no alineado a la izquierda');
-assert.strictEqual(maxX, 20, 'triángulo alargado no alineado a la derecha');
+assert.strictEqual(minX, 0, 'diamante alargado no alineado a la izquierda');
+assert.strictEqual(maxX, 20, 'diamante alargado no alineado a la derecha');
 
 console.log('Pruebas de figuras geométricas completadas');

--- a/utils.js
+++ b/utils.js
@@ -264,10 +264,13 @@ function drawNoteShape(ctx, shape, x, y, width, height, stroke = false) {
       ctx.closePath();
       break;
     }
-    case 'triangle': {
-      ctx.moveTo(x + width / 2, y);
-      ctx.lineTo(x + width, y + height);
-      ctx.lineTo(x, y + height);
+    case 'diamond': {
+      const midX = x + width / 2;
+      const midY = y + height / 2;
+      ctx.moveTo(x, midY);
+      ctx.lineTo(midX, y);
+      ctx.lineTo(x + width, midY);
+      ctx.lineTo(midX, y + height);
       ctx.closePath();
       break;
     }
@@ -320,7 +323,7 @@ const SHAPE_OPTIONS = [
   { value: 'oval', label: 'Óvalo alargado' },
   { value: 'capsule', label: 'Cápsula alargada' },
   { value: 'star', label: 'Estrella alargada' },
-  { value: 'triangle', label: 'Triángulo alargado' },
+  { value: 'diamond', label: 'Diamante alargado' },
   { value: 'circle', label: 'Círculo' },
   { value: 'square', label: 'Cuadrado' },
   { value: 'star4', label: 'Estrella 4 puntas' },
@@ -398,10 +401,16 @@ function canStartPlayback(audioBuffer, notes) {
   return !!(audioBuffer || (Array.isArray(notes) && notes.length > 0));
 }
 
-// Inicia un bucle de animación a fps constantes utilizando setInterval
+// Inicia un bucle de animación a fps constantes utilizando setInterval y rAF
 function startFixedFPSLoop(callback, fps = 60) {
   const interval = 1000 / fps;
-  const id = setInterval(callback, interval);
+  const id = setInterval(() => {
+    if (typeof requestAnimationFrame !== 'undefined') {
+      requestAnimationFrame(callback);
+    } else {
+      callback();
+    }
+  }, interval);
   return () => clearInterval(id);
 }
 


### PR DESCRIPTION
## Summary
- replace elongated triangle shape with straight-edged diamond and update defaults
- hide mouse cursor when entering fullscreen and smooth the animation loop
- polish UI with unified button styling and professional layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa06cfe7248333a1bd02baae3f7999