### PR TITLE
Normalize instrument names and scale panel fonts

### DIFF
--- a/script.js
+++ b/script.js
@@ -795,13 +795,13 @@ const INSTRUMENT_FAMILIES = {
   Oboe: 'Dobles cañas',
   Clarinete: 'Dobles cañas',
   Fagot: 'Dobles cañas',
-  Saxofón: 'Saxofones',
+  Saxofon: 'Saxofones',
   Trompeta: 'Metales',
-  Trombón: 'Metales',
+  Trombon: 'Metales',
   Tuba: 'Metales',
-  'Corno francés': 'Metales',
+  'Corno frances': 'Metales',
   Piano: 'Cuerdas pulsadas',
-  Violín: 'Cuerdas frotadas',
+  Violin: 'Cuerdas frotadas',
   Viola: 'Cuerdas frotadas',
   Violonchelo: 'Cuerdas frotadas',
   Contrabajo: 'Cuerdas frotadas',
@@ -810,6 +810,9 @@ const INSTRUMENT_FAMILIES = {
 
 const normalizeInstrumentName = (name) =>
   name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+
+const stripAccents = (name) =>
+  name.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 
 const NORMALIZED_INSTRUMENT_MAP = Object.keys(INSTRUMENT_FAMILIES).reduce(
   (acc, inst) => {
@@ -825,13 +828,13 @@ const INSTRUMENT_COLOR_SHIFT = {
   Clarinete: -0.2,
   Oboe: 0,
   Fagot: -0.3,
-  Saxofón: -0.1,
+  Saxofon: -0.1,
   Trompeta: 0.1,
-  Trombón: -0.1,
+  Trombon: -0.1,
   Tuba: -0.2,
-  'Corno francés': 0,
+  'Corno frances': 0,
   Piano: 0,
-  Violín: 0.1,
+  Violin: 0.1,
   Viola: 0,
   Violonchelo: -0.1,
   Contrabajo: -0.2,
@@ -1027,7 +1030,7 @@ function importConfiguration(json, tracks = []) {
 function assignTrackInfo(tracks) {
   return tracks.map((t) => {
     const key = normalizeInstrumentName(t.name);
-    const instrument = NORMALIZED_INSTRUMENT_MAP[key] || t.name;
+    const instrument = NORMALIZED_INSTRUMENT_MAP[key] || stripAccents(t.name);
     const family = INSTRUMENT_FAMILIES[instrument] || 'Desconocida';
     const preset = FAMILY_PRESETS[family] || { shape: 'unknown', color: '#ffffff' };
     const color = getInstrumentColor(preset, instrument);

--- a/styles.css
+++ b/styles.css
@@ -43,28 +43,30 @@ select:hover {
 }
 
 #family-config-panel {
-  display: none;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin: 0 10px 10px;
-  background: #222;
-  padding: 10px;
-  width: calc(100% - 20px);
-  justify-content: center;
-}
+    display: none;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin: 0 10px 10px;
+    background: #222;
+    padding: 10px;
+    width: calc(100% - 20px);
+    justify-content: center;
+    font-size: 0.7rem;
+  }
 
 #family-config-panel.active {
   display: flex;
 }
 
 #developer-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  width: 100%;
-  margin-bottom: 10px;
-  justify-content: center;
-}
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    width: 100%;
+    margin-bottom: 10px;
+    justify-content: center;
+    font-size: 0.7rem;
+  }
 
 .dev-control {
   display: flex;

--- a/test_instrument_accents.js
+++ b/test_instrument_accents.js
@@ -2,13 +2,13 @@ const assert = require('assert');
 const { assignTrackInfo } = require('./script');
 
 const tracks = assignTrackInfo([
-  { name: 'Saxofon', events: [] },
-  { name: 'Corno frances', events: [] },
+  { name: 'Saxofón', events: [] },
+  { name: 'Corno francés', events: [] },
 ]);
 
-assert.strictEqual(tracks[0].instrument, 'Saxofón');
+assert.strictEqual(tracks[0].instrument, 'Saxofon');
 assert.strictEqual(tracks[0].family, 'Saxofones');
-assert.strictEqual(tracks[1].instrument, 'Corno francés');
+assert.strictEqual(tracks[1].instrument, 'Corno frances');
 assert.strictEqual(tracks[1].family, 'Metales');
 
 console.log('Pruebas de reconocimiento de tildes completadas');


### PR DESCRIPTION
## Summary
- Remove accents from instrument names to avoid rendering issues
- Add accent stripping utility and update instrument-family mappings
- Reduce font size to 70% in family and developer panels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa0b2251648333b8e3065d947c58fd