### PR TITLE
Fix default config loading and enlarge title font

### DIFF
--- a/script.js
+++ b/script.js
@@ -1070,11 +1070,20 @@ function importConfiguration(json, tracks = []) {
 }
 
 async function loadDefaultConfiguration(tracks = []) {
-  if (typeof fetch !== 'function') return Promise.resolve();
   try {
-    const response = await fetch('configuracion.json');
-    if (!response.ok) return;
-    const data = await response.json();
+    let data;
+    if (typeof window === 'undefined' && typeof require === 'function') {
+      const fs = require('fs');
+      const path = require('path');
+      const filePath = path.join(__dirname || '.', 'configuracion.json');
+      data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    } else if (typeof fetch === 'function') {
+      const response = await fetch('configuracion.json');
+      if (!response.ok) return;
+      data = await response.json();
+    } else {
+      return;
+    }
     importConfiguration(data, tracks);
   } catch (err) {
     /* Silent failure loading default configuration */

--- a/styles.css
+++ b/styles.css
@@ -11,7 +11,7 @@ body {
 
 #app-title {
   margin: 20px 0 10px;
-  font-size: 1rem;
+  font-size: 2.5rem;
   font-weight: 700;
 }
 


### PR DESCRIPTION
## Summary
- Load `configuracion.json` reliably by falling back to the filesystem when running outside the browser
- Increase app title font size by 150%

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa3ab3f3f88333b1904ecfe183e667