### PR TITLE
Fix family color and shape application after configuration import

### DIFF
--- a/script.js
+++ b/script.js
@@ -414,7 +414,7 @@ if (typeof document !== 'undefined') {
         if (!file) return;
         const reader = new FileReader();
         reader.onload = (ev) => {
-          importConfiguration(ev.target.result, currentTracks);
+          importConfiguration(ev.target.result, currentTracks, notes);
           populateInstrumentDropdown(currentTracks);
           buildFamilyPanel();
         };
@@ -538,7 +538,7 @@ if (typeof document !== 'undefined') {
 
     buildFamilyPanel();
 
-    loadDefaultConfiguration(currentTracks)
+    loadDefaultConfiguration(currentTracks, notes)
       .catch(() => {})
       .then(() => {
         populateInstrumentDropdown(currentTracks);
@@ -1016,7 +1016,7 @@ function exportConfiguration() {
   });
 }
 
-function importConfiguration(json, tracks = []) {
+function importConfiguration(json, tracks = [], notes = []) {
   const data = typeof json === 'string' ? JSON.parse(json) : json;
   assignedFamilies = data.assignedFamilies || {};
   const famCustoms = data.familyCustomizations || {};
@@ -1067,9 +1067,17 @@ function importConfiguration(json, tracks = []) {
     t.shape = preset.shape;
     t.color = getInstrumentColor(preset, t.instrument);
   });
+  notes.forEach((n) => {
+    const fam = assignedFamilies[n.instrument] || n.family;
+    n.family = fam;
+    const preset =
+      FAMILY_PRESETS[fam] || { shape: 'unknown', color: '#ffffff' };
+    n.shape = preset.shape;
+    n.color = getInstrumentColor(preset, n.instrument);
+  });
 }
 
-async function loadDefaultConfiguration(tracks = []) {
+async function loadDefaultConfiguration(tracks = [], notes = []) {
   try {
     let data;
     if (typeof window === 'undefined' && typeof require === 'function') {
@@ -1084,7 +1092,7 @@ async function loadDefaultConfiguration(tracks = []) {
     } else {
       return;
     }
-    importConfiguration(data, tracks);
+    importConfiguration(data, tracks, notes);
   } catch (err) {
     /* Silent failure loading default configuration */
   }

--- a/test_config_export_import.js
+++ b/test_config_export_import.js
@@ -12,6 +12,18 @@ const {
 } = require('./script.js');
 
 const tracks = assignTrackInfo([{ name: 'Flauta', events: [] }]);
+const notes = [
+  {
+    start: 0,
+    end: 1,
+    noteNumber: 60,
+    velocity: 64,
+    color: tracks[0].color,
+    shape: tracks[0].shape,
+    family: tracks[0].family,
+    instrument: tracks[0].instrument,
+  },
+];
 
 const config = {
   assignedFamilies: { Flauta: 'Metales' },
@@ -23,7 +35,7 @@ const config = {
   bumpControl: 1.2,
 };
 
-importConfiguration(config, tracks);
+importConfiguration(config, tracks, notes);
 
 assert.strictEqual(tracks[0].family, 'Metales');
 assert.strictEqual(tracks[0].shape, 'diamond');
@@ -32,6 +44,9 @@ const expectedColor = adjustColorBrightness(
   INSTRUMENT_COLOR_SHIFT['Flauta']
 );
 assert.strictEqual(tracks[0].color, expectedColor);
+assert.strictEqual(notes[0].family, 'Metales');
+assert.strictEqual(notes[0].shape, 'diamond');
+assert.strictEqual(notes[0].color, expectedColor);
 
 assert.strictEqual(getVelocityBase(), 80);
 assert.deepStrictEqual(getOpacityScale(), { edge: 0.1, mid: 0.8 });


### PR DESCRIPTION
## Summary
- Refresh notes when importing configuration so colors and shapes apply immediately
- Load default configuration with notes and ensure import handler passes notes
- Cover configuration import behavior with updated unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa3c3fafd083338d9e2defdcfdc9d3