### PR TITLE
Decode MIDI track names as UTF-8

### DIFF
--- a/script.js
+++ b/script.js
@@ -1115,11 +1115,11 @@ function parseMIDI(arrayBuffer) {
   let offset = 0;
 
   const readString = (len) => {
-    let s = '';
+    const bytes = new Uint8Array(len);
     for (let i = 0; i < len; i++) {
-      s += String.fromCharCode(data.getUint8(offset++));
+      bytes[i] = data.getUint8(offset++);
     }
-    return s;
+    return new TextDecoder('utf-8').decode(bytes);
   };
 
   const readUint32 = () => {


### PR DESCRIPTION
## Summary
- Decode MIDI track names using UTF-8 to ensure instruments with accents are recognized correctly.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa3ea3e1048333bd3bc2dd4c1cdb87