### PR TITLE
Preserve instrument name accents

### DIFF
--- a/script.js
+++ b/script.js
@@ -829,33 +829,32 @@ const INSTRUMENT_FAMILIES = {
   Oboe: 'Dobles cañas',
   Clarinete: 'Dobles cañas',
   Fagot: 'Dobles cañas',
-  Saxofon: 'Saxofones',
+  Saxofón: 'Saxofones',
   Trompeta: 'Metales',
-  Trombon: 'Metales',
+  Trombón: 'Metales',
   Tuba: 'Metales',
-  'Corno frances': 'Metales',
+  'Corno francés': 'Metales',
   Piano: 'Cuerdas pulsadas',
-  Violin: 'Cuerdas frotadas',
+  Violín: 'Cuerdas frotadas',
   Viola: 'Cuerdas frotadas',
   Violonchelo: 'Cuerdas frotadas',
   Contrabajo: 'Cuerdas frotadas',
   Voz: 'Voces',
 };
 
-const stripAccents = (name) => {
-  let cleaned = name;
+// Normaliza codificación y conserva caracteres con acento
+const normalizeAccents = (name) => {
+  let decoded = name;
   try {
-    cleaned = decodeURIComponent(escape(name));
+    decoded = decodeURIComponent(escape(name));
   } catch (e) {
     // Si falla la decodificación, se usa el nombre original
   }
-  return cleaned
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^\x00-\x7F]/g, '');
+  return decoded.normalize('NFC');
 };
 
-const normalizeInstrumentName = (name) => stripAccents(name).toLowerCase();
+const normalizeInstrumentName = (name) =>
+  normalizeAccents(name).toLowerCase();
 
 const NORMALIZED_INSTRUMENT_MAP = Object.keys(INSTRUMENT_FAMILIES).reduce(
   (acc, inst) => {
@@ -871,13 +870,13 @@ const INSTRUMENT_COLOR_SHIFT = {
   Clarinete: -0.2,
   Oboe: 0,
   Fagot: -0.3,
-  Saxofon: -0.1,
+  Saxofón: -0.1,
   Trompeta: 0.1,
-  Trombon: -0.1,
+  Trombón: -0.1,
   Tuba: -0.2,
-  'Corno frances': 0,
+  'Corno francés': 0,
   Piano: 0,
-  Violin: 0.1,
+  Violín: 0.1,
   Viola: 0,
   Violonchelo: -0.1,
   Contrabajo: -0.2,
@@ -1102,7 +1101,7 @@ async function loadDefaultConfiguration(tracks = [], notes = []) {
 function assignTrackInfo(tracks) {
   return tracks.map((t) => {
     const key = normalizeInstrumentName(t.name);
-    const instrument = NORMALIZED_INSTRUMENT_MAP[key] || stripAccents(t.name);
+    const instrument = NORMALIZED_INSTRUMENT_MAP[key] || normalizeAccents(t.name);
     const family = INSTRUMENT_FAMILIES[instrument] || 'Desconocida';
     const preset = FAMILY_PRESETS[family] || { shape: 'unknown', color: '#ffffff' };
     const color = getInstrumentColor(preset, instrument);

--- a/test_instrument_accents.js
+++ b/test_instrument_accents.js
@@ -8,13 +8,13 @@ const tracks = assignTrackInfo([
   { name: 'Corno francÃ©s', events: [] },
 ]);
 
-assert.strictEqual(tracks[0].instrument, 'Saxofon');
+assert.strictEqual(tracks[0].instrument, 'Saxofón');
 assert.strictEqual(tracks[0].family, 'Saxofones');
-assert.strictEqual(tracks[1].instrument, 'Corno frances');
+assert.strictEqual(tracks[1].instrument, 'Corno francés');
 assert.strictEqual(tracks[1].family, 'Metales');
-assert.strictEqual(tracks[2].instrument, 'Saxofon');
+assert.strictEqual(tracks[2].instrument, 'Saxofón');
 assert.strictEqual(tracks[2].family, 'Saxofones');
-assert.strictEqual(tracks[3].instrument, 'Corno frances');
+assert.strictEqual(tracks[3].instrument, 'Corno francés');
 assert.strictEqual(tracks[3].family, 'Metales');
 
 console.log('Pruebas de reconocimiento de tildes completadas');

--- a/test_instrument_persistence.js
+++ b/test_instrument_persistence.js
@@ -12,17 +12,17 @@ let { setInstrumentEnabled, getVisibleNotes } = require('./script');
 
 const notes = [
   { instrument: 'Flauta', start: 0, end: 1, noteNumber: 60, color: '#fff', shape: 'oval', family: 'Maderas de timbre "redondo"', velocity: 67 },
-  { instrument: 'Violin', start: 0, end: 1, noteNumber: 65, color: '#fff', shape: 'diamond', family: 'Cuerdas frotadas', velocity: 67 },
+  { instrument: 'Violín', start: 0, end: 1, noteNumber: 65, color: '#fff', shape: 'diamond', family: 'Cuerdas frotadas', velocity: 67 },
 ];
 
 setInstrumentEnabled('Flauta', false);
-setInstrumentEnabled('Violin', true);
+setInstrumentEnabled('Violín', true);
 
 delete require.cache[require.resolve('./script')];
 ({ getVisibleNotes } = require('./script'));
 
 const visible = getVisibleNotes(notes);
 assert.strictEqual(visible.length, 1);
-assert.strictEqual(visible[0].instrument, 'Violin');
+assert.strictEqual(visible[0].instrument, 'Violín');
 
 console.log('Pruebas de persistencia de instrumentos completadas');

--- a/test_instrument_toggle.js
+++ b/test_instrument_toggle.js
@@ -3,14 +3,14 @@ const { getVisibleNotes, setInstrumentEnabled } = require('./script');
 
 const notes = [
   { instrument: 'Flauta', start: 0, end: 1, noteNumber: 60, color: '#fff', shape: 'oval', family: 'Maderas de timbre "redondo"' },
-  { instrument: 'Violin', start: 0, end: 1, noteNumber: 65, color: '#fff', shape: 'diamond', family: 'Cuerdas frotadas' },
+  { instrument: 'Violín', start: 0, end: 1, noteNumber: 65, color: '#fff', shape: 'diamond', family: 'Cuerdas frotadas' },
 ];
 
 setInstrumentEnabled('Flauta', false);
-setInstrumentEnabled('Violin', true);
+setInstrumentEnabled('Violín', true);
 
 const visible = getVisibleNotes(notes);
 assert.strictEqual(visible.length, 1);
-assert.strictEqual(visible[0].instrument, 'Violin');
+assert.strictEqual(visible[0].instrument, 'Violín');
 
 console.log('Pruebas de activación/desactivación de instrumentos completadas');


### PR DESCRIPTION
## Summary
- Keep accented characters in instrument names and mappings
- Normalize instrument names without stripping accents
- Update tests to reflect accented instrument names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa4084a3548333906eb0b3d217ec1b