### PR TITLE
Fix instrument name encoding and default text size

### DIFF
--- a/configuracion.json
+++ b/configuracion.json
@@ -1,1 +1,146 @@
-{"assignedFamilies":{"Flautn":"Maderas de timbre \"redondo\"","Flauta 1":"Maderas de timbre \"redondo\"","Flauta 2":"Maderas de timbre \"redondo\"","Clarinete (Si Bemol) I":"Maderas de timbre \"redondo\"","Clarinete (Si Bemol) II":"Maderas de timbre \"redondo\"","Clarinete (Si Bemol) III":"Maderas de timbre \"redondo\"","Clarinete bajo":"Maderas de timbre \"redondo\"","Oboe 1":"Dobles cañas","Oboe 2":"Dobles cañas","Fagot 1":"Dobles cañas","Fagot 2":"Dobles cañas","Saxofn soprano":"Saxofones","Saxofn alto":"Saxofones","Saxofn tenor":"Saxofones","Saxofn bartono":"Saxofones","Corno francs (Sol) 1":"Metales","Corno francs (Sol) 2":"Metales","Corno francs (Sol) 3":"Metales","Corno francs (Sol) 4":"Metales","Trompeta (Si Bemol) 1":"Metales","Trompeta (Si Bemol) 2":"Metales","Trompeta (Si Bemol) 3":"Metales","Trompeta (Si Bemol) 4":"Metales","Trombn 1":"Metales","Trombn 2":"Metales","Trombn 3":"Metales","Trombn 4":"Metales","Bombardino (Si Bemol) 1":"Metales","Bombardino (Si Bemol) 2":"Metales","Tuba":"Metales","Percusin":"Percusión menor","Claves":"Percusión menor","Timbal de concierto":"Tambores","Conga":"Tambores","Platillo de orquesta":"Platillos","Piano":"Auxiliares","Contrabajo":"Cuerdas frotadas","Violn":"Cuerdas frotadas","Track 0":"Auxiliares"},"familyCustomizations":{"Metales":{"color":"#ffb900","shape":"capsule","colorBright":"#ffea00","colorDark":"#ff8800"},"Maderas de timbre \"redondo\"":{"color":"#769df3","shape":"oval","colorBright":"#96b5fe","colorDark":"#5585e7"},"Dobles cañas":{"color":"#c23afd","shape":"star","colorBright":"#fd6bff","colorDark":"#8609fb"},"Saxofones":{"color":"#ce8767","shape":"star","colorBright":"#e39d7d","colorDark":"#b97150"},"Placas":{"color":"#ff0000","shape":"square","colorBright":"#ff7070"},"Auxiliares":{"color":"#347875","shape":"circle","colorBright":"#54aba1","colorDark":"#134549"},"Cuerdas frotadas":{"color":"#41e342","shape":"diamond","colorBright":"#62fe43","colorDark":"#1fc740"},"Cuerdas pulsadas":{"color":"#1abeb4","shape":"star4","colorBright":"#16dac3","colorDark":"#1da2a5"},"Voces":{"color":"#bebebe","shape":"capsule","colorBright":"#d1d1d1","colorDark":"#ababab"}},"enabledInstruments":{"Track 0":true,"Flautn":true,"Flauta 1":true,"Flauta 2":true,"Oboe 1":true,"Oboe 2":true,"Clarinete (Si Bemol) I":true,"Clarinete (Si Bemol) II":true,"Clarinete (Si Bemol) III":true,"Clarinete bajo":true,"Fagot 1":true,"Fagot 2":true,"Saxofn soprano":true,"Saxofn alto":true,"Saxofn tenor":true,"Saxofn bartono":true,"Corno francs (Sol) 1":true,"Corno francs (Sol) 2":true,"Corno francs (Sol) 3":true,"Corno francs (Sol) 4":true,"Trompeta (Si Bemol) 1":true,"Trompeta (Si Bemol) 2":true,"Trompeta (Si Bemol) 3":true,"Trompeta (Si Bemol) 4":true,"Trombn 1":true,"Trombn 2":true,"Trombn 3":true,"Trombn 4":true,"Bombardino (Si Bemol) 1":true,"Bombardino (Si Bemol) 2":true,"Tuba":true,"Contrabajo":true,"Timbal de concierto":false,"Platillo de orquesta":false,"Percusin":false,"Conga":false,"Claves":true,"Violn":true,"Piano":false},"velocityBase":127,"opacityScale":{"edge":0,"mid":0.48},"glowStrength":0.9,"bumpControl":0.9}
+{
+  "assignedFamilies": {
+    "Flautín": "Maderas de timbre \"redondo\"",
+    "Flauta 1": "Maderas de timbre \"redondo\"",
+    "Flauta 2": "Maderas de timbre \"redondo\"",
+    "Clarinete (Si Bemol) I": "Maderas de timbre \"redondo\"",
+    "Clarinete (Si Bemol) II": "Maderas de timbre \"redondo\"",
+    "Clarinete (Si Bemol) III": "Maderas de timbre \"redondo\"",
+    "Clarinete bajo": "Maderas de timbre \"redondo\"",
+    "Oboe 1": "Dobles cañas",
+    "Oboe 2": "Dobles cañas",
+    "Fagot 1": "Dobles cañas",
+    "Fagot 2": "Dobles cañas",
+    "Saxofón soprano": "Saxofones",
+    "Saxofón alto": "Saxofones",
+    "Saxofón tenor": "Saxofones",
+    "Saxofón barítono": "Saxofones",
+    "Corno francés (Sol) 1": "Metales",
+    "Corno francés (Sol) 2": "Metales",
+    "Corno francés (Sol) 3": "Metales",
+    "Corno francés (Sol) 4": "Metales",
+    "Trompeta (Si Bemol) 1": "Metales",
+    "Trompeta (Si Bemol) 2": "Metales",
+    "Trompeta (Si Bemol) 3": "Metales",
+    "Trompeta (Si Bemol) 4": "Metales",
+    "Trombón 1": "Metales",
+    "Trombón 2": "Metales",
+    "Trombón 3": "Metales",
+    "Trombón 4": "Metales",
+    "Bombardino (Si Bemol) 1": "Metales",
+    "Bombardino (Si Bemol) 2": "Metales",
+    "Tuba": "Metales",
+    "Percusión": "Percusión menor",
+    "Claves": "Percusión menor",
+    "Timbal de concierto": "Tambores",
+    "Conga": "Tambores",
+    "Platillo de orquesta": "Platillos",
+    "Piano": "Auxiliares",
+    "Contrabajo": "Cuerdas frotadas",
+    "Violín": "Cuerdas frotadas",
+    "Track 0": "Auxiliares"
+  },
+  "familyCustomizations": {
+    "Metales": {
+      "color": "#ffb900",
+      "shape": "capsule",
+      "colorBright": "#ffea00",
+      "colorDark": "#ff8800"
+    },
+    "Maderas de timbre \"redondo\"": {
+      "color": "#769df3",
+      "shape": "oval",
+      "colorBright": "#96b5fe",
+      "colorDark": "#5585e7"
+    },
+    "Dobles cañas": {
+      "color": "#c23afd",
+      "shape": "star",
+      "colorBright": "#fd6bff",
+      "colorDark": "#8609fb"
+    },
+    "Saxofones": {
+      "color": "#ce8767",
+      "shape": "star",
+      "colorBright": "#e39d7d",
+      "colorDark": "#b97150"
+    },
+    "Placas": {
+      "color": "#ff0000",
+      "shape": "square",
+      "colorBright": "#ff7070"
+    },
+    "Auxiliares": {
+      "color": "#347875",
+      "shape": "circle",
+      "colorBright": "#54aba1",
+      "colorDark": "#134549"
+    },
+    "Cuerdas frotadas": {
+      "color": "#41e342",
+      "shape": "diamond",
+      "colorBright": "#62fe43",
+      "colorDark": "#1fc740"
+    },
+    "Cuerdas pulsadas": {
+      "color": "#1abeb4",
+      "shape": "star4",
+      "colorBright": "#16dac3",
+      "colorDark": "#1da2a5"
+    },
+    "Voces": {
+      "color": "#bebebe",
+      "shape": "capsule",
+      "colorBright": "#d1d1d1",
+      "colorDark": "#ababab"
+    }
+  },
+  "enabledInstruments": {
+    "Track 0": true,
+    "Flautín": true,
+    "Flauta 1": true,
+    "Flauta 2": true,
+    "Oboe 1": true,
+    "Oboe 2": true,
+    "Clarinete (Si Bemol) I": true,
+    "Clarinete (Si Bemol) II": true,
+    "Clarinete (Si Bemol) III": true,
+    "Clarinete bajo": true,
+    "Fagot 1": true,
+    "Fagot 2": true,
+    "Saxofón soprano": true,
+    "Saxofón alto": true,
+    "Saxofón tenor": true,
+    "Saxofón barítono": true,
+    "Corno francés (Sol) 1": true,
+    "Corno francés (Sol) 2": true,
+    "Corno francés (Sol) 3": true,
+    "Corno francés (Sol) 4": true,
+    "Trompeta (Si Bemol) 1": true,
+    "Trompeta (Si Bemol) 2": true,
+    "Trompeta (Si Bemol) 3": true,
+    "Trompeta (Si Bemol) 4": true,
+    "Trombón 1": true,
+    "Trombón 2": true,
+    "Trombón 3": true,
+    "Trombón 4": true,
+    "Bombardino (Si Bemol) 1": true,
+    "Bombardino (Si Bemol) 2": true,
+    "Tuba": true,
+    "Contrabajo": true,
+    "Timbal de concierto": false,
+    "Platillo de orquesta": false,
+    "Percusión": false,
+    "Conga": false,
+    "Claves": true,
+    "Violín": true,
+    "Piano": false
+  },
+  "velocityBase": 127,
+  "opacityScale": {
+    "edge": 0,
+    "mid": 0.48
+  },
+  "glowStrength": 0.9,
+  "bumpControl": 0.9
+}

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <button id="aspect-9-16">9:16</button>
     <button id="full-screen">Pantalla completa</button>
     <label for="font-size-control">Tamaño texto</label>
-    <input type="range" id="font-size-control" min="0.8" max="1.5" step="0.1" value="1" />
+    <input type="range" id="font-size-control" min="0.8" max="1.5" step="0.1" value="0.8" />
   </nav>
 
   <canvas id="visualizer" width="1280" height="720"></canvas>

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /* Estilos básicos para la estructura inicial */
 :root {
-  --global-font-size: 1rem;
+  --global-font-size: 0.8rem;
 }
 body {
   margin: 0;

--- a/test_font_size_control.js
+++ b/test_font_size_control.js
@@ -4,7 +4,7 @@ const { initializeFontSizeControl } = require('./ui');
 
 const dom = new JSDOM(`<!DOCTYPE html><html><body>
 <h1 id="app-title" style="font-size:2.5rem"></h1>
-<input type="range" id="font-size-control" value="1" />
+<input type="range" id="font-size-control" value="0.8" />
 </body></html>`);
 
 global.document = dom.window.document;
@@ -14,7 +14,7 @@ initializeFontSizeControl({ slider, target: document.documentElement });
 
 assert.strictEqual(
   document.documentElement.style.getPropertyValue('--global-font-size'),
-  '1rem'
+  '0.8rem'
 );
 
 slider.value = '1.3';


### PR DESCRIPTION
## Summary
- Correct default configuration so instrument names display accents properly
- Initialize global font size at minimal 0.8rem and adjust slider/test defaults

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa46ac2c708333968e20f61bbfafee