### PR TITLE
feat: enhance font selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,12 +58,8 @@
     </select>
     <select id="font-select">
       <option value="">Fuente</option>
-      <option value="Arial">Arial</option>
-      <option value="Verdana">Verdana</option>
-      <option value="Times New Roman">Times New Roman</option>
-      <option value="Georgia">Georgia</option>
-      <option value="Courier New">Courier New</option>
     </select>
+    <input id="font-size" type="number" value="16" min="8" max="72" />
     <button id="toggle-family-panel">▼</button>
     <button id="developer-mode">Modo desarrollador</button>
   </nav>

--- a/script.js
+++ b/script.js
@@ -107,8 +107,13 @@ if (typeof document !== 'undefined') {
     const modalFamilyZones = document.getElementById('modal-family-zones');
     const applyAssignmentsBtn = document.getElementById('apply-assignments');
     const fontSelect = document.getElementById('font-select');
+    const fontSizeInput = document.getElementById('font-size');
     if (fontSelect) {
-      initFontSelector({ select: fontSelect, target: document.documentElement });
+      initFontSelector({
+        select: fontSelect,
+        sizeInput: fontSizeInput,
+        target: document.documentElement,
+      });
     }
     
     let velocityBase = getVelocityBase();

--- a/styles.css
+++ b/styles.css
@@ -45,6 +45,11 @@ body {
   min-width: 150px;
 }
 
+#bottom-menu #font-size {
+  flex: 0 0 60px;
+  min-width: 60px;
+}
+
 #bottom-menu #toggle-family-panel {
   flex: 0 0 40px;
   text-align: center;
@@ -52,13 +57,15 @@ body {
 }
 
 #bottom-menu select,
-#bottom-menu button {
+#bottom-menu button,
+#bottom-menu input {
   width: 100%;
   text-align: center;
 }
 
 button,
-select {
+select,
+input {
   background: #333;
   border: 1px solid #555;
   color: #fff;
@@ -69,7 +76,8 @@ select {
 }
 
 button:hover,
-select:hover {
+select:hover,
+input:hover {
   background: #444;
   cursor: pointer;
 }

--- a/test_font_selector.js
+++ b/test_font_selector.js
@@ -3,21 +3,44 @@ const { JSDOM } = require('jsdom');
 const { initializeFontSelector } = require('./ui');
 
 const dom = new JSDOM(`<!DOCTYPE html><html><body>
-<select id="font-select">
-  <option value="">Fuente</option>
-  <option value="Arial">Arial</option>
-</select>
+<select id="font-select"><option value="">Fuente</option></select>
+<input id="font-size" type="number" value="16" />
 </body></html>`, { pretendToBeVisual: true });
 
 global.document = dom.window.document;
+global.window = dom.window;
 
-const select = document.getElementById('font-select');
+global.navigator = {
+  fonts: {
+    query: async () => [{ family: 'Arial' }, { family: 'Courier New' }],
+  },
+};
 
-initializeFontSelector({ select, target: document.documentElement });
+(async () => {
+  const select = document.getElementById('font-select');
+  const sizeInput = document.getElementById('font-size');
 
-select.value = 'Arial';
-select.dispatchEvent(new dom.window.Event('change'));
+  await initializeFontSelector({
+    select,
+    sizeInput,
+    target: document.documentElement,
+  });
 
-assert.strictEqual(document.documentElement.style.fontFamily, '"Arial", sans-serif');
+  assert.strictEqual(select.options.length, 3);
 
-console.log('Prueba de selector de fuente completada');
+  select.value = 'Courier New';
+  select.dispatchEvent(new dom.window.Event('change'));
+  assert.strictEqual(
+    document.documentElement.style.fontFamily,
+    '"Courier New", sans-serif'
+  );
+
+  sizeInput.value = '20';
+  sizeInput.dispatchEvent(new dom.window.Event('input'));
+  assert.strictEqual(
+    document.documentElement.style.getPropertyValue('--global-font-size'),
+    '20px'
+  );
+
+  console.log('Prueba de selector de fuente completada');
+})();


### PR DESCRIPTION
## Summary
- load system fonts when available and apply choice immediately
- add numeric font-size box with mouse drag control
- update tests for font selection and sizing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa4cb02094833386e5811e4c82905a