### PR TITLE
fix: load default config locally and enable font switching

### DIFF
--- a/configuracion.js
+++ b/configuracion.js
@@ -1,0 +1,146 @@
+window.DEFAULT_CONFIG = {
+  "assignedFamilies": {
+    "Flautín": "Maderas de timbre \"redondo\"",
+    "Flauta 1": "Maderas de timbre \"redondo\"",
+    "Flauta 2": "Maderas de timbre \"redondo\"",
+    "Clarinete (Si Bemol) I": "Maderas de timbre \"redondo\"",
+    "Clarinete (Si Bemol) II": "Maderas de timbre \"redondo\"",
+    "Clarinete (Si Bemol) III": "Maderas de timbre \"redondo\"",
+    "Clarinete bajo": "Maderas de timbre \"redondo\"",
+    "Oboe 1": "Dobles cañas",
+    "Oboe 2": "Dobles cañas",
+    "Fagot 1": "Dobles cañas",
+    "Fagot 2": "Dobles cañas",
+    "Saxofón soprano": "Saxofones",
+    "Saxofón alto": "Saxofones",
+    "Saxofón tenor": "Saxofones",
+    "Saxofón barítono": "Saxofones",
+    "Corno francés (Sol) 1": "Metales",
+    "Corno francés (Sol) 2": "Metales",
+    "Corno francés (Sol) 3": "Metales",
+    "Corno francés (Sol) 4": "Metales",
+    "Trompeta (Si Bemol) 1": "Metales",
+    "Trompeta (Si Bemol) 2": "Metales",
+    "Trompeta (Si Bemol) 3": "Metales",
+    "Trompeta (Si Bemol) 4": "Metales",
+    "Trombón 1": "Metales",
+    "Trombón 2": "Metales",
+    "Trombón 3": "Metales",
+    "Trombón 4": "Metales",
+    "Bombardino (Si Bemol) 1": "Metales",
+    "Bombardino (Si Bemol) 2": "Metales",
+    "Tuba": "Metales",
+    "Percusión": "Percusión menor",
+    "Claves": "Percusión menor",
+    "Timbal de concierto": "Tambores",
+    "Conga": "Tambores",
+    "Platillo de orquesta": "Platillos",
+    "Piano": "Auxiliares",
+    "Contrabajo": "Cuerdas frotadas",
+    "Violín": "Cuerdas frotadas",
+    "Track 0": "Auxiliares"
+  },
+  "familyCustomizations": {
+    "Metales": {
+      "color": "#ffb900",
+      "shape": "capsule",
+      "colorBright": "#ffea00",
+      "colorDark": "#ff8800"
+    },
+    "Maderas de timbre \"redondo\"": {
+      "color": "#769df3",
+      "shape": "oval",
+      "colorBright": "#96b5fe",
+      "colorDark": "#5585e7"
+    },
+    "Dobles cañas": {
+      "color": "#c23afd",
+      "shape": "star",
+      "colorBright": "#fd6bff",
+      "colorDark": "#8609fb"
+    },
+    "Saxofones": {
+      "color": "#ce8767",
+      "shape": "star",
+      "colorBright": "#e39d7d",
+      "colorDark": "#b97150"
+    },
+    "Placas": {
+      "color": "#ff0000",
+      "shape": "square",
+      "colorBright": "#ff7070"
+    },
+    "Auxiliares": {
+      "color": "#347875",
+      "shape": "circle",
+      "colorBright": "#54aba1",
+      "colorDark": "#134549"
+    },
+    "Cuerdas frotadas": {
+      "color": "#41e342",
+      "shape": "diamond",
+      "colorBright": "#62fe43",
+      "colorDark": "#1fc740"
+    },
+    "Cuerdas pulsadas": {
+      "color": "#1abeb4",
+      "shape": "star4",
+      "colorBright": "#16dac3",
+      "colorDark": "#1da2a5"
+    },
+    "Voces": {
+      "color": "#bebebe",
+      "shape": "capsule",
+      "colorBright": "#d1d1d1",
+      "colorDark": "#ababab"
+    }
+  },
+  "enabledInstruments": {
+    "Track 0": true,
+    "Flautín": true,
+    "Flauta 1": true,
+    "Flauta 2": true,
+    "Oboe 1": true,
+    "Oboe 2": true,
+    "Clarinete (Si Bemol) I": true,
+    "Clarinete (Si Bemol) II": true,
+    "Clarinete (Si Bemol) III": true,
+    "Clarinete bajo": true,
+    "Fagot 1": true,
+    "Fagot 2": true,
+    "Saxofón soprano": true,
+    "Saxofón alto": true,
+    "Saxofón tenor": true,
+    "Saxofón barítono": true,
+    "Corno francés (Sol) 1": true,
+    "Corno francés (Sol) 2": true,
+    "Corno francés (Sol) 3": true,
+    "Corno francés (Sol) 4": true,
+    "Trompeta (Si Bemol) 1": true,
+    "Trompeta (Si Bemol) 2": true,
+    "Trompeta (Si Bemol) 3": true,
+    "Trompeta (Si Bemol) 4": true,
+    "Trombón 1": true,
+    "Trombón 2": true,
+    "Trombón 3": true,
+    "Trombón 4": true,
+    "Bombardino (Si Bemol) 1": true,
+    "Bombardino (Si Bemol) 2": true,
+    "Tuba": true,
+    "Contrabajo": true,
+    "Timbal de concierto": false,
+    "Platillo de orquesta": false,
+    "Percusión": false,
+    "Conga": false,
+    "Claves": true,
+    "Violín": true,
+    "Piano": false
+  },
+  "velocityBase": 127,
+  "opacityScale": {
+    "edge": 0,
+    "mid": 0.48
+  },
+  "glowStrength": 0.9,
+  "bumpControl": 0.9
+};

--- a/index.html
+++ b/index.html
@@ -89,6 +89,7 @@
   <script src="wavLoader.js"></script>
   <script src="audioPlayer.js"></script>
   <script src="ui.js"></script>
+  <script src="configuracion.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1095,7 +1095,12 @@ async function loadDefaultConfiguration(tracks = [], notes = []) {
       const path = require('path');
       const filePath = path.join(__dirname || '.', 'configuracion.json');
       data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-    } else if (typeof fetch === 'function') {
+    } else if (typeof window !== 'undefined' && window.DEFAULT_CONFIG) {
+      data = window.DEFAULT_CONFIG;
+    } else if (
+      typeof fetch === 'function' &&
+      !(typeof window !== 'undefined' && window.location.protocol === 'file:')
+    ) {
       const response = await fetch('configuracion.json');
       if (!response.ok) return;
       data = await response.json();

--- a/styles.css
+++ b/styles.css
@@ -2,6 +2,7 @@
 /* Estilos básicos para la estructura inicial */
 :root {
   --global-font-size: 0.8rem;
+  font-family: 'Roboto', Arial, Helvetica, sans-serif;
 }
 body {
   margin: 0;
@@ -10,7 +11,7 @@ body {
   align-items: center;
   background-color: #111;
   color: #fff;
-  font-family: 'Roboto', Arial, Helvetica, sans-serif;
+  font-family: inherit;
   font-size: var(--global-font-size);
 }
 


### PR DESCRIPTION
## Summary
- avoid CORS error when running from file:// by loading default configuration from embedded script
- make font selector effective by inheriting fonts from root

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa4dfa30408333a83a452a04018855