### PR TITLE
Improve instrument name normalization for family detection

### DIFF
--- a/script.js
+++ b/script.js
@@ -861,10 +861,11 @@ const normalizeAccents = (name) => {
 const normalizeInstrumentName = (name) =>
   normalizeAccents(name)
     .toLowerCase()
+    .normalize('NFD').replace(/\p{Diacritic}/gu, '') // elimina diacríticos para coincidencias flexibles
     .replace(/\(.*?\)/g, '') // elimina texto entre paréntesis
     .replace(/\b[ivx]+\b/g, '') // elimina numerales romanos
     .replace(/\d+/g, '') // elimina dígitos
-    .replace(/[^a-záéíóúüñ\s]/g, '') // remueve otros caracteres
+    .replace(/[^\p{L}\s]/gu, '') // remueve caracteres no alfabéticos, preservando cualquier letra Unicode
     .replace(/\s+/g, ' ') // colapsa espacios múltiples
     .trim();
 


### PR DESCRIPTION
## Summary
- Preserve all Unicode letters when normalizing instrument names
- Strip diacritics before matching so family lookup works with accented or unusual characters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa52b553d08333b90bae1aec09524d