### PR TITLE
feat: add solo espressivo figure

### DIFF
--- a/test_shapes.js
+++ b/test_shapes.js
@@ -49,6 +49,7 @@ const shapes = [
   ['star', 'lineToCalled'],
   ['star4', 'lineToCalled'],
   ['pentagon', 'lineToCalled'],
+  ['soloEspressivo', 'lineToCalled'],
 ];
 
 shapes.forEach(([shape, expected]) => {

--- a/utils.js
+++ b/utils.js
@@ -5,6 +5,9 @@
  */
 
 (function (global) {
+// Integración de nuevas figuras
+const { drawSoloEspressivo } = require('./soloEspressivo.js');
+
 // Cache simple para evitar recalcular ajustes de color
 const colorCache = new Map();
 
@@ -310,6 +313,9 @@ function drawNoteShape(ctx, shape, x, y, width, height, stroke = false) {
       ctx.closePath();
       break;
     }
+    case 'soloEspressivo':
+      drawSoloEspressivo(ctx, x, y, width, height);
+      break;
     default:
       ctx.rect(x, y, width, height);
   }
@@ -328,6 +334,7 @@ const SHAPE_OPTIONS = [
   { value: 'square', label: 'Cuadrado' },
   { value: 'star4', label: 'Estrella 4 puntas' },
   { value: 'pentagon', label: 'Pentágono' },
+  { value: 'soloEspressivo', label: 'Solo esspresivo' },
 ];
 
 function getFamilyModifiers(family) {


### PR DESCRIPTION
## Summary
- add Solo esspresivo figure with left alignment, opacity and glow support
- expose figure in shape menu and rendering pipeline
- cover Solo esspresivo in shape tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa57dda1088333b4b71be3392776b3