### PR TITLE
fix: support utils without require

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,7 @@
     </div>
   </div>
 
+  <script src="soloEspressivo.js"></script>
   <script src="utils.js"></script>
   <script src="midiLoader.js"></script>
   <script src="wavLoader.js"></script>

--- a/utils.js
+++ b/utils.js
@@ -6,7 +6,14 @@
 
 (function (global) {
 // Integración de nuevas figuras
-const { drawSoloEspressivo } = require('./soloEspressivo.js');
+// En navegadores no existe `require`, así que se intenta obtener la
+// función desde el objeto global si no está disponible CommonJS.
+let drawSoloEspressivo;
+if (typeof require !== 'undefined') {
+  ({ drawSoloEspressivo } = require('./soloEspressivo.js'));
+} else {
+  drawSoloEspressivo = global.drawSoloEspressivo;
+}
 
 // Cache simple para evitar recalcular ajustes de color
 const colorCache = new Map();


### PR DESCRIPTION
## Summary
- allow `utils.js` to load drawSoloEspressivo when `require` is unavailable
- ensure soloEspressivo module is loaded in browser

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa5ad558288333bca199cd8348e66c