### PR TITLE
fix: make soloEspressivo browser-friendly

### DIFF
--- a/script.js
+++ b/script.js
@@ -45,8 +45,9 @@ const { loadWavFile } =
   typeof require !== 'undefined' ? require('./wavLoader.js') : window.wavLoader;
 const { createAudioPlayer } =
   typeof require !== 'undefined' ? require('./audioPlayer.js') : window.audioPlayer;
-const { createSoloEspressivoRenderer } =
-  typeof require !== 'undefined' ? require('./soloEspressivo.js') : window;
+const {
+  createSoloEspressivoRenderer: createSoloEspressivoRendererFn,
+} = typeof require !== 'undefined' ? require('./soloEspressivo.js') : window;
 
 // Estado de activación de instrumentos
 const enabledInstruments =
@@ -238,7 +239,7 @@ if (typeof document !== 'undefined') {
       return yTop + noteHeight / 2;
     };
 
-    let soloEspressivo = createSoloEspressivoRenderer({ pitchToY });
+    let soloEspressivo = createSoloEspressivoRendererFn({ pitchToY });
 
     function saveAssignments() {
       if (typeof localStorage !== 'undefined') {
@@ -718,7 +719,7 @@ if (typeof document !== 'undefined') {
     function prepareNotesFromTracks(tracks, tempoMapRaw, timeDivision) {
       notes = [];
       nextNoteId = 0;
-      soloEspressivo = createSoloEspressivoRenderer({ pitchToY });
+      soloEspressivo = createSoloEspressivoRendererFn({ pitchToY });
       tempoMap = preprocessTempoMap(tempoMapRaw, timeDivision);
       tracks.forEach((track) => {
         track.events.forEach((ev) => {
@@ -828,7 +829,7 @@ if (typeof document !== 'undefined') {
     if (typeof window !== 'undefined') {
       window.__renderFrame = renderFrame;
       window.__setTestNotes = (n) => {
-        soloEspressivo = createSoloEspressivoRenderer({ pitchToY });
+        soloEspressivo = createSoloEspressivoRendererFn({ pitchToY });
         nextNoteId = 0;
         notes = n.map((note) => ({ ...note, id: nextNoteId++ }));
       };

--- a/soloEspressivo.js
+++ b/soloEspressivo.js
@@ -1,90 +1,204 @@
 // viz/soloEspressivo.js
 
-// Convertido a CommonJS para integrarlo con el resto de la app
-function createSoloEspressivoRenderer({
-  pitchToY = (p, H) => Math.round(H * 0.5 - (p - 69) * 5),
-  connectMaxGapMs = 700,
-  vib = { f0: 2.5, f1: 3.2, amp0: 12, amp1: 22 },
-  rightMargin = 28,
-} = {}) {
-  const notes = [];
-  const mix = (a,b,t)=>a+(b-a)*t;
-  const eio = t=> t<.5?4*t*t*t:1-Math.pow(-2*t+2,3)/2;
-  const grad = (ctx,W)=>{ const g=ctx.createLinearGradient(0,0,W,0); g.addColorStop(0,'#f7f0dd'); g.addColorStop(.35,'#e6d5a9'); g.addColorStop(.7,'#c6b07e'); g.addColorStop(1,'#b29b6d'); return g; };
-  const spiral = (cx,cy,t)=>{ const th=t*4*Math.PI, r=mix(4,24,eio(t)); return {x:cx+r*Math.cos(th), y:cy+r*Math.sin(th)}; };
-  const tailRTL = (x0,y,len,s)=>({x:x0-len*s,y});
-  const stroke = (ctx,a,b,s,style,wScale=1)=>{ const maxW=26,minW=2,tPow=1.8; const w=(minW+(maxW-minW)*Math.pow(1-s,tPow))*wScale; ctx.strokeStyle=style; ctx.lineWidth=w; ctx.lineCap='round'; ctx.lineJoin='round'; ctx.beginPath(); ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); ctx.stroke(); };
-  const dot = (ctx,x,y)=>{ ctx.beginPath(); ctx.fillStyle='#f1e6cb'; ctx.arc(x,y-18,4.2,0,Math.PI*2); ctx.fill(); };
-  const rnd = i=> (Math.sin(i*1234)*43758.5453)%1;
+// Compatible con entornos CommonJS y navegador mediante IIFE
+(function (global) {
+  function createSoloEspressivoRenderer({
+    pitchToY = (p, H) => Math.round(H * 0.5 - (p - 69) * 5),
+    connectMaxGapMs = 700,
+    vib = { f0: 2.5, f1: 3.2, amp0: 12, amp1: 22 },
+    rightMargin = 28,
+  } = {}) {
+    const notes = [];
+    const mix = (a, b, t) => a + (b - a) * t;
+    const eio = (t) => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2);
+    const grad = (ctx, W) => {
+      const g = ctx.createLinearGradient(0, 0, W, 0);
+      g.addColorStop(0, '#f7f0dd');
+      g.addColorStop(0.35, '#e6d5a9');
+      g.addColorStop(0.7, '#c6b07e');
+      g.addColorStop(1, '#b29b6d');
+      return g;
+    };
+    const spiral = (cx, cy, t) => {
+      const th = t * 4 * Math.PI;
+      const r = mix(4, 24, eio(t));
+      return { x: cx + r * Math.cos(th), y: cy + r * Math.sin(th) };
+    };
+    const tailRTL = (x0, y, len, s) => ({ x: x0 - len * s, y });
+    const stroke = (ctx, a, b, s, style, wScale = 1) => {
+      const maxW = 26,
+        minW = 2,
+        tPow = 1.8;
+      const w = (minW + (maxW - minW) * Math.pow(1 - s, tPow)) * wScale;
+      ctx.strokeStyle = style;
+      ctx.lineWidth = w;
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+      ctx.beginPath();
+      ctx.moveTo(a.x, a.y);
+      ctx.lineTo(b.x, b.y);
+      ctx.stroke();
+    };
+    const dot = (ctx, x, y) => {
+      ctx.beginPath();
+      ctx.fillStyle = '#f1e6cb';
+      ctx.arc(x, y - 18, 4.2, 0, Math.PI * 2);
+      ctx.fill();
+    };
+    const rnd = (i) => (Math.sin(i * 1234) * 43758.5453) % 1;
 
-  function drawShort(ctx,W,y){ const xR=W-rightMargin, g=grad(ctx,W); let pv=spiral(xR,y,0); for(let i=1;i<=200;i++){const s=i/200, p=spiral(xR,y,s); stroke(ctx,pv,p,s,g); pv=p;} dot(ctx,xR,y); }
-  function drawLongStatic(ctx,W,y,durMs){ const xR=W-rightMargin, g=grad(ctx,W); const len=Math.max(60,Math.min(W*0.8,durMs*0.18)); let ps=spiral(xR,y,0); for(let i=1;i<=200;i++){const s=i/200, p=spiral(xR,y,s); stroke(ctx,ps,p,s,g); ps=p;} let pt=tailRTL(xR+18,y,len,0); for(let i=1;i<=360;i++){const s=i/360, p=tailRTL(xR+18,y,len,s); stroke(ctx,pt,p,s,g); pt=p;} return len; }
-  function drawVibrato(ctx,W,y,len,onElapsed,onProg){ const f=vib.f0+(vib.f1-vib.f0)*eio(onProg), a=vib.amp0+(vib.amp1-vib.amp0)*eio(onProg), ph=2*Math.PI*f*onElapsed, xR=W-rightMargin; let pv={x:xR+18,y:y+a*Math.sin(ph)}; for(let i=1;i<=360;i++){const s=i/360, x=xR+18-len*s, sp=s*Math.PI, yy=y+a*Math.sin(ph+sp); stroke(ctx,pv,{x,y:yy},s,'#f1e6cb',0.9); pv={x,y:yy};} }
-  function drawConnector(ctx,W,yA,yB,gapMs){ if(gapMs>connectMaxGapMs) return; const x0=W-rightMargin, opp=(yB>yA?-1:1), ratio=1-(gapMs/connectMaxGapMs); const w0=1+1.2*ratio, alpha=0.5+0.5*ratio; const c1={x:x0-45,y:yA+opp*18}, c2={x:x0-160,y:mix(yA,yB,0.6)-opp*10}; ctx.save(); ctx.strokeStyle='#d6ccb3'; ctx.globalAlpha=alpha; let pv={x:x0,y:yA}; const N=90; for(let i=1;i<=N;i++){ const t=i/N; const x=Math.pow(1-t,3)*x0 + 3*Math.pow(1-t,2)*t*c1.x + 3*(1-t)*t*t*c2.x + Math.pow(t,3)*x0; const y=Math.pow(1-t,3)*yA + 3*Math.pow(1-t,2)*t*c1.y + 3*(1-t)*t*t*c2.y + Math.pow(t,3)*yB; const wS=mix(w0,0.7,t); const jx=(rnd(i)-0.5)*0.8, jy=(rnd(i+1)-0.5)*0.8; stroke(ctx,pv,{x:x+jx,y:y+jy},t,'#d6ccb3',wS); pv={x:x+jx,y:y+jy}; } ctx.restore(); }
-
-  return {
-    noteOn({ id, pitch, startMs, durMs }){
-      notes.push({ id, pitch, startMs, durMs, endMs: null, isShort: durMs < 150 });
-    },
-    noteOff({ id, endMs }){
-      const n = notes.find((x) => x.id === id);
-      if (n) n.endMs = endMs;
-    },
-    render(ctx, nowMs){
-      const W = ctx.canvas.width;
-      const H = ctx.canvas.height;
-      const list = [...notes].sort((a, b) => a.startMs - b.startMs);
-      let prev = null;
-      for (const n of list) {
-        n.y ??= pitchToY(n.pitch, H);
-        if (n.isShort) {
-          drawShort(ctx, W, n.y);
-        } else {
-          n.lenPx ??= drawLongStatic(ctx, W, n.y, n.durMs);
-          const on0 = n.startMs;
-          const on1 = n.endMs ?? (n.startMs + n.durMs);
-          if (nowMs >= on0 && nowMs <= on1) {
-            const el = (nowMs - on0) / 1000;
-            const pr = Math.max(0, Math.min(1, (nowMs - on0) / n.durMs));
-            drawVibrato(ctx, W, n.y, n.lenPx, el, pr);
-          }
-        }
-        if (prev) {
-          const g = Math.max(0, n.startMs - (prev.endMs ?? (prev.startMs + prev.durMs)));
-          drawConnector(ctx, W, prev.y, n.y, g);
-        }
-        prev = n;
+    function drawShort(ctx, W, y) {
+      const xR = W - rightMargin,
+        g = grad(ctx, W);
+      let pv = spiral(xR, y, 0);
+      for (let i = 1; i <= 200; i++) {
+        const s = i / 200,
+          p = spiral(xR, y, s);
+        stroke(ctx, pv, p, s, g);
+        pv = p;
       }
-    },
-  };
-}
+      dot(ctx, xR, y);
+    }
+    function drawLongStatic(ctx, W, y, durMs) {
+      const xR = W - rightMargin,
+        g = grad(ctx, W);
+      const len = Math.max(60, Math.min(W * 0.8, durMs * 0.18));
+      let ps = spiral(xR, y, 0);
+      for (let i = 1; i <= 200; i++) {
+        const s = i / 200,
+          p = spiral(xR, y, s);
+        stroke(ctx, ps, p, s, g);
+        ps = p;
+      }
+      let pt = tailRTL(xR + 18, y, len, 0);
+      for (let i = 1; i <= 360; i++) {
+        const s = i / 360,
+          p = tailRTL(xR + 18, y, len, s);
+        stroke(ctx, pt, p, s, g);
+        pt = p;
+      }
+      return len;
+    }
+    function drawVibrato(ctx, W, y, len, onElapsed, onProg) {
+      const f = vib.f0 + (vib.f1 - vib.f0) * eio(onProg),
+        a = vib.amp0 + (vib.amp1 - vib.amp0) * eio(onProg),
+        ph = 2 * Math.PI * f * onElapsed,
+        xR = W - rightMargin;
+      let pv = { x: xR + 18, y: y + a * Math.sin(ph) };
+      for (let i = 1; i <= 360; i++) {
+        const s = i / 360,
+          x = xR + 18 - len * s,
+          sp = s * Math.PI,
+          yy = y + a * Math.sin(ph + sp);
+        stroke(ctx, pv, { x, y: yy }, s, '#f1e6cb', 0.9);
+        pv = { x, y: yy };
+      }
+    }
+    function drawConnector(ctx, W, yA, yB, gapMs) {
+      if (gapMs > connectMaxGapMs) return;
+      const x0 = W - rightMargin,
+        opp = yB > yA ? -1 : 1,
+        ratio = 1 - gapMs / connectMaxGapMs;
+      const w0 = 1 + 1.2 * ratio,
+        alpha = 0.5 + 0.5 * ratio;
+      const c1 = { x: x0 - 45, y: yA + opp * 18 },
+        c2 = { x: x0 - 160, y: mix(yA, yB, 0.6) - opp * 10 };
+      ctx.save();
+      ctx.strokeStyle = '#d6ccb3';
+      ctx.globalAlpha = alpha;
+      let pv = { x: x0, y: yA };
+      const N = 90;
+      for (let i = 1; i <= N; i++) {
+        const t = i / N;
+        const x =
+          Math.pow(1 - t, 3) * x0 +
+          3 * Math.pow(1 - t, 2) * t * c1.x +
+          3 * (1 - t) * t * t * c2.x +
+          Math.pow(t, 3) * x0;
+        const y =
+          Math.pow(1 - t, 3) * yA +
+          3 * Math.pow(1 - t, 2) * t * c1.y +
+          3 * (1 - t) * t * t * c2.y +
+          Math.pow(t, 3) * yB;
+        const wS = mix(w0, 0.7, t);
+        const jx = (rnd(i) - 0.5) * 0.8,
+          jy = (rnd(i + 1) - 0.5) * 0.8;
+        stroke(ctx, pv, { x: x + jx, y: y + jy }, t, '#d6ccb3', wS);
+        pv = { x: x + jx, y: y + jy };
+      }
+      ctx.restore();
+    }
 
-// Dibuja una versión simplificada de la figura "Solo espressivo" alineada a la izquierda
-// para ser utilizada como una forma dentro de la app.
-function drawSoloEspressivo(ctx, x, y, width, height) {
-  const mix = (a, b, t) => a + (b - a) * t;
-  const eio = (t) => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2);
-  const spiral = (cx, cy, t) => {
-    const th = t * 4 * Math.PI;
-    const r = mix(height * 0.1, height * 0.5, eio(t));
-    return { x: cx + r * Math.cos(th), y: cy + r * Math.sin(th) };
-  };
-
-  const cx = x + height * 0.3;
-  const cy = y + height / 2;
-  const steps = 40;
-  let p = spiral(cx, cy, 0);
-  ctx.moveTo(p.x, p.y);
-  for (let i = 1; i <= steps; i++) {
-    p = spiral(cx, cy, i / steps);
-    ctx.lineTo(p.x, p.y);
+    return {
+      noteOn({ id, pitch, startMs, durMs }) {
+        notes.push({ id, pitch, startMs, durMs, endMs: null, isShort: durMs < 150 });
+      },
+      noteOff({ id, endMs }) {
+        const n = notes.find((x) => x.id === id);
+        if (n) n.endMs = endMs;
+      },
+      render(ctx, nowMs) {
+        const W = ctx.canvas.width;
+        const H = ctx.canvas.height;
+        const list = [...notes].sort((a, b) => a.startMs - b.startMs);
+        let prev = null;
+        for (const n of list) {
+          n.y ??= pitchToY(n.pitch, H);
+          if (n.isShort) {
+            drawShort(ctx, W, n.y);
+          } else {
+            n.lenPx ??= drawLongStatic(ctx, W, n.y, n.durMs);
+            const on0 = n.startMs;
+            const on1 = n.endMs ?? n.startMs + n.durMs;
+            if (nowMs >= on0 && nowMs <= on1) {
+              const el = (nowMs - on0) / 1000;
+              const pr = Math.max(0, Math.min(1, (nowMs - on0) / n.durMs));
+              drawVibrato(ctx, W, n.y, n.lenPx, el, pr);
+            }
+          }
+          if (prev) {
+            const g = Math.max(0, n.startMs - (prev.endMs ?? prev.startMs + prev.durMs));
+            drawConnector(ctx, W, prev.y, n.y, g);
+          }
+          prev = n;
+        }
+      },
+    };
   }
-  // Cola hacia la derecha
-  ctx.lineTo(x + width, cy);
-  ctx.lineTo(x + width, cy + height * 0.1);
-  ctx.lineTo(x, cy + height * 0.1);
-  ctx.closePath();
-}
 
-module.exports = { createSoloEspressivoRenderer, drawSoloEspressivo };
+  // Dibuja una versión simplificada de la figura "Solo espressivo" alineada a la izquierda
+  // para ser utilizada como una forma dentro de la app.
+  function drawSoloEspressivo(ctx, x, y, width, height) {
+    const mix = (a, b, t) => a + (b - a) * t;
+    const eio = (t) => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2);
+    const spiral = (cx, cy, t) => {
+      const th = t * 4 * Math.PI;
+      const r = mix(height * 0.1, height * 0.5, eio(t));
+      return { x: cx + r * Math.cos(th), y: cy + r * Math.sin(th) };
+    };
+
+    const cx = x + height * 0.3;
+    const cy = y + height / 2;
+    const steps = 40;
+    let p = spiral(cx, cy, 0);
+    ctx.moveTo(p.x, p.y);
+    for (let i = 1; i <= steps; i++) {
+      p = spiral(cx, cy, i / steps);
+      ctx.lineTo(p.x, p.y);
+    }
+    // Cola hacia la derecha
+    ctx.lineTo(x + width, cy);
+    ctx.lineTo(x + width, cy + height * 0.1);
+    ctx.lineTo(x, cy + height * 0.1);
+    ctx.closePath();
+  }
+
+  const api = { createSoloEspressivoRenderer, drawSoloEspressivo };
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  } else {
+    global.createSoloEspressivoRenderer = createSoloEspressivoRenderer;
+    global.drawSoloEspressivo = drawSoloEspressivo;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this);
 


### PR DESCRIPTION
## Summary
- wrap soloEspressivo renderer in a universal module that works in browser and CommonJS
- avoid global identifier collision by aliasing renderer in main script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa5e7f12048333aee2bc211193e01b