### PR TITLE
Enable MusicXML file support

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
   <input
     type="file"
     id="midi-file-input"
-    accept=".mid,.midi,.xml"
+    accept=".mid,.midi,.xml,.musicxml"
     style="display: none"
   />
 

--- a/midiLoader.js
+++ b/midiLoader.js
@@ -22,7 +22,7 @@
           }
         };
         reader.readAsArrayBuffer(file);
-      } else if (ext === 'xml') {
+      } else if (ext === 'xml' || ext === 'musicxml') {
         reader.onload = (ev) => {
           try {
             const xml = parsers.parseMusicXML(ev.target.result);

--- a/test_parsers.js
+++ b/test_parsers.js
@@ -4,6 +4,7 @@ const {
   parseMusicXML,
   assignTrackInfo,
 } = require('./script.js');
+const { loadMusicFile } = require('./midiLoader.js');
 
 // Prueba para parseMIDI con un archivo mínimo en memoria
 function testParseMIDI() {
@@ -85,6 +86,52 @@ function testAssignTrackInfo() {
   console.log('assignTrackInfo OK');
 }
 
+// Prueba de carga de archivo con extensión .musicxml
+function testLoadMusicFileMusicXML() {
+  const xml = `
+    <score-partwise version="3.1">
+      <part-list>
+        <score-part id="P1">
+          <part-name>Piano</part-name>
+        </score-part>
+      </part-list>
+      <part id="P1">
+        <measure number="1">
+          <attributes>
+            <divisions>1</divisions>
+          </attributes>
+          <note>
+            <pitch>
+              <step>C</step>
+              <octave>4</octave>
+            </pitch>
+            <duration>1</duration>
+          </note>
+        </measure>
+      </part>
+    </score-partwise>`;
+
+  global.FileReader = class {
+    constructor() {
+      this.onload = null;
+    }
+    readAsText(file) {
+      if (this.onload) this.onload({ target: { result: file.content } });
+    }
+    readAsArrayBuffer() {}
+  };
+
+  const file = { name: 'test.musicxml', content: xml };
+  return loadMusicFile(file, { parseMIDI: () => {}, parseMusicXML }).then((res) => {
+    assert.strictEqual(res.tracks.length, 1);
+    console.log('loadMusicFile .musicxml OK');
+  });
+}
+
 testParseMIDI();
 testParseMusicXML();
 testAssignTrackInfo();
+testLoadMusicFileMusicXML().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- allow uploading of files with `.musicxml` extension
- handle `.musicxml` in file loader
- test MusicXML file loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa66005aac8333861c54528132fea0