### PR TITLE
Remove MusicXML support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,21 +2,21 @@ PLAN DE DESARROLLO DE APP WEB
 
 App web: Visualizador MIDI - Jaime Jaramillo Arias
 
-Descripción: la app permite cargar archivos MIDI o XML de música para generar una animación y visualizar el contenido del archivo MIDI. Permite también cargar archivos WAV para reproducir al tiempo con la animación.
+Descripción: la app permite cargar archivos MIDI de música para generar una animación y visualizar el contenido del archivo MIDI. Permite también cargar archivos WAV para reproducir al tiempo con la animación.
 
 El objetivo fundamental de la app, es producir animaciones detalladas, fluidas y complejas, de la más alta calidad.
 
 Elementos de la UI:
 
 1.	Titulo.
-2.	Menú superior con los siguientes botones, de izquierda a derecha: “Cargar MIDI/XML”, “Cargar WAV”, “Play/Stop” (atado a la barra espaciadora), “Adelantar” (adelanta 3 segundos), “Atrasar” (atrasa 3 segundos), “Inicio”, “16:9”, “9:16”, “Pantalla completa” (este botón amplía el canvas en la resolución elegida a la pantalla completa, y la app debe hacer super sampleo de los pixeles para no perder claridad).
+2.	Menú superior con los siguientes botones, de izquierda a derecha: “Cargar MIDI”, “Cargar WAV”, “Play/Stop” (atado a la barra espaciadora), “Adelantar” (adelanta 3 segundos), “Atrasar” (atrasa 3 segundos), “Inicio”, “16:9”, “9:16”, “Pantalla completa” (este botón amplía el canvas en la resolución elegida a la pantalla completa, y la app debe hacer super sampleo de los pixeles para no perder claridad).
 3.	Canvas. El Canvas principal debe tener 720px de altura, ya sea en 16:9 o en 9:16. Ya cuando se pase a pantalla completa, la resolución debe aumentar.
 4.	Menú inferior con los siguientes botones, de izquierda a derecha: “Instrumento” (drop down para seleccionar los instrumentos del archivo MIDI cargado), “Familia” (drop down para seleccionar la familia a la que pertenece el instrumento seleccionado en el drop down anterior), la lista de familias siempre debe estar completa así no esté cargado ningún instrumento, las familias son: Maderas de timbre “redondo”, Dobles cañas, Saxofones, Metales, Percusión menor, Tambores, Platillos, Placas, Auxiliares, Cuerdas frotadas, Cuerdas pulsadas, Voces. 
 5.	Panel inferior desplegable mediante un botón tipo “flecha” que muestra una lista de todas las familias, con la posibilidad de elegir el color y la figura geométrica para las animaciones de los instrumentos a los que se les adjudique esa familia.
 
 Lógica de importación de archivos:
 
-1.	El botón de “Cargar MIDI/XML” abre una ventana para cargar localmente un archivo MIDI o XML de música.
+1.	El botón de “Cargar MIDI” abre una ventana para cargar localmente un archivo MIDI de música.
 2.	La app debe extraer la siguiente información: note ON, note OFF, note duration, note velocity, tempo map, track names.
 3.	La app debe adjudicar a cada instrumento una familia según su track name.
 4.	El botón de “Cargar WAV” abre una ventana para cargar localmente un archivo WAV.

--- a/agents_tareas
+++ b/agents_tareas
@@ -1,5 +1,5 @@
 1. [x] Configurar la estructura base del proyecto web (HTML, CSS, JS) y mostrar un canvas de 720px de alto junto a los menús superior e inferior sin funcionalidades.
-2. [x] Implementar botón “Cargar MIDI/XML” y lógica básica para leer archivos MIDI/XML extrayendo note ON/OFF, duración, velocidad, tempo y nombres de pista.
+2. [x] Implementar botón “Cargar MIDI” y lógica básica para leer archivos MIDI extrayendo note ON/OFF, duración, velocidad, tempo y nombres de pista.
 3. [x] Implementar botón “Cargar WAV” y reproducción de audio, eliminando silencios iniciales y sincronizando el playhead con la animación.
 4. [x] Crear estructura de datos que relacione cada pista con su instrumento y familia, asignando formas y colores predeterminados.
 5. [x] Dibujar notas básicas en el canvas desplazándose de derecha a izquierda, alineadas con NOTE ON/OFF y la línea de presente al centro.
@@ -10,7 +10,7 @@
 10. [x] Añadir opciones de aspecto 16:9 y 9:16, con soporte para pantalla completa y supermuestreo.
 11. [x] Implementar menú inferior con dropdowns de Instrumento y Familia siempre visibles, y panel desplegable para personalizar color y figura por familia.
 12. [x] Optimizar rendimiento y modularizar el código con comentarios claros para facilitar el desarrollo incremental.
-13. [x] Implementar pruebas unitarias básicas para las funciones de parseo de archivos MIDI y MusicXML.
+13. [x] Implementar pruebas unitarias básicas para las funciones de parseo de archivos MIDI.
 14. [x] Integrar la estructura de pistas con el menú inferior, poblando dinámicamente el dropdown de instrumentos según los archivos cargados.
 15. [x] Renderizar rectángulos estáticos en el canvas representando notas basadas en eventos (subtarea de la 5).
 16. [x] Animar las notas desplazándose de derecha a izquierda sincronizadas con el tiempo.
@@ -36,7 +36,7 @@
 36. [x] El color de fondo del canvas debe ser negro absoluto, pero en el panel inferior debe existir la posibilidad de cambiar el color del canvas.
 37. [x] La línea de presente debe ser invisible.
 38. [x] Las cápsulas deben ser rectángulos con esquinas redondeadas.
-39. [x] El botón de play debe funcionar así esté cargado solo el MIDI/XML sin audio, o el audio sin MIDI/XML.
+39. [x] El botón de play debe funcionar así esté cargado solo el MIDI sin audio, o el audio sin MIDI.
 40. [x] La animación debe estar en 60 fps fijos SIEMPRE, y no depender de la frecuencia de la pantalla.
 41. [x] La velocidad del midi debe salir del tempo map, y NO ser una velocidad constante.
 42. [x] El brillo de las figuras al pasar por la línea de presente debe ser de tipo glow/blur, y parecer una sombra más que una línea definida.
@@ -44,7 +44,7 @@
 44. [x] En algún menú debe existir la posibilidad de activar o desactivar instrumentos para incluirlos o eliminarlos de la animación.
 45. [x] Crear pruebas unitarias para la personalización del color del canvas.
 46. [x] Corregir el bug que impedía aplicar el color de fondo seleccionado al canvas en cada frame.
-47. [x] Crear pruebas unitarias para el botón Play funcionando con solo MIDI/XML o solo WAV.
+47. [x] Crear pruebas unitarias para el botón Play funcionando con solo MIDI o solo WAV.
 
 48. [x] Crear pruebas unitarias para mantener la animación a 60 fps constantes.
 49. [x] Crear pruebas unitarias para la reproducción basada en el tempo map.

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
   <h1 id="app-title">Visualizador MIDI - Jaime Jaramillo Arias</h1>
   <nav id="top-menu">
-    <button id="load-midi">Cargar MIDI/XML</button>
+    <button id="load-midi">Cargar MIDI</button>
     <button id="load-wav">Cargar WAV</button>
     <button id="play-stop">Play/Stop</button>
     <button id="seek-forward">Adelantar</button>
@@ -25,7 +25,7 @@
   <input
     type="file"
     id="midi-file-input"
-    accept=".mid,.midi,.xml,.musicxml"
+    accept=".mid,.midi"
     style="display: none"
   />
 

--- a/midiLoader.js
+++ b/midiLoader.js
@@ -22,26 +22,6 @@
           }
         };
         reader.readAsArrayBuffer(file);
-      } else if (ext.endsWith('xml')) {
-        reader.onload = (ev) => {
-          try {
-            const xml = parsers.parseMusicXML(ev.target.result);
-            const tempoMap = [
-              {
-                time: 0,
-                microsecondsPerBeat: (60 / xml.tempo) * 1e6,
-              },
-            ];
-            resolve({
-              tracks: xml.tracks,
-              tempoMap,
-              timeDivision: xml.divisions,
-            });
-          } catch (err) {
-            reject(err);
-          }
-        };
-        reader.readAsText(file);
       } else {
         reject(new Error('Formato no soportado'));
       }

--- a/test_parsers.js
+++ b/test_parsers.js
@@ -1,9 +1,5 @@
 const assert = require('assert');
-const {
-  parseMIDI,
-  parseMusicXML,
-  assignTrackInfo,
-} = require('./script.js');
+const { parseMIDI, assignTrackInfo } = require('./script.js');
 const { loadMusicFile } = require('./midiLoader.js');
 
 // Prueba para parseMIDI con un archivo mínimo en memoria
@@ -40,37 +36,6 @@ function testParseMIDI() {
   console.log('parseMIDI OK');
 }
 
-// Prueba básica para parseMusicXML
-function testParseMusicXML() {
-  const xml = `
-    <score-partwise version="3.1">
-      <part-list>
-        <score-part id="P1">
-          <part-name>Piano</part-name>
-        </score-part>
-      </part-list>
-      <part id="P1">
-        <measure number="1">
-          <attributes>
-            <divisions>1</divisions>
-          </attributes>
-          <note>
-            <pitch>
-              <step>C</step>
-              <octave>4</octave>
-            </pitch>
-            <duration>1</duration>
-          </note>
-        </measure>
-      </part>
-    </score-partwise>`;
-  const result = parseMusicXML(xml);
-  assert.strictEqual(result.tracks.length, 1);
-  const note = result.tracks[0].events[0];
-  assert.strictEqual(note.noteNumber, 60);
-  console.log('parseMusicXML OK');
-}
-
 // Prueba para asignación de familia e instrumentación
 function testAssignTrackInfo() {
   const tracks = [
@@ -86,86 +51,50 @@ function testAssignTrackInfo() {
   console.log('assignTrackInfo OK');
 }
 
-// Prueba de carga de archivo con extensión .musicxml
-function testLoadMusicFileMusicXML() {
-  const xml = `
-    <score-partwise version="3.1">
-      <part-list>
-        <score-part id="P1">
-          <part-name>Piano</part-name>
-        </score-part>
-      </part-list>
-      <part id="P1">
-        <measure number="1">
-          <attributes>
-            <divisions>1</divisions>
-          </attributes>
-          <note>
-            <pitch>
-              <step>C</step>
-              <octave>4</octave>
-            </pitch>
-            <duration>1</duration>
-          </note>
-        </measure>
-      </part>
-    </score-partwise>`;
+function testLoadMusicFileMIDI() {
+  const header = [
+    0x4d, 0x54, 0x68, 0x64,
+    0x00, 0x00, 0x00, 0x06,
+    0x00, 0x00,
+    0x00, 0x01,
+    0x00, 0x60,
+  ];
+  const trackEvents = [
+    0x00, 0xff, 0x03, 0x04, 0x74, 0x65, 0x73, 0x74,
+    0x00, 0x90, 0x3c, 0x40,
+    0x60, 0x80, 0x3c, 0x40,
+    0x00, 0xff, 0x2f, 0x00,
+  ];
+  const trackLength = trackEvents.length;
+  const trackHeader = [
+    0x4d, 0x54, 0x72, 0x6b,
+    (trackLength >> 24) & 0xff,
+    (trackLength >> 16) & 0xff,
+    (trackLength >> 8) & 0xff,
+    trackLength & 0xff,
+  ];
+  const bytes = new Uint8Array([...header, ...trackHeader, ...trackEvents]);
 
   global.FileReader = class {
     constructor() {
       this.onload = null;
     }
-    readAsText(file) {
+    readAsArrayBuffer() {
       if (this.onload) this.onload({ target: { result: file.content } });
     }
-    readAsArrayBuffer() {}
+    readAsText() {}
   };
 
-  const file = { name: 'test.musicxml', content: xml };
-  return loadMusicFile(file, { parseMIDI: () => {}, parseMusicXML }).then((res) => {
+  const file = { name: 'test.mid', content: bytes.buffer };
+  return loadMusicFile(file, { parseMIDI }).then((res) => {
     assert.strictEqual(res.tracks.length, 1);
-    console.log('loadMusicFile .musicxml OK');
+    console.log('loadMusicFile .mid OK');
   });
 }
 
-// Prueba para parseMusicXML con namespace por defecto
-function testParseMusicXMLNamespace() {
-  const { JSDOM } = require('jsdom');
-  global.DOMParser = new JSDOM().window.DOMParser;
-  const xml = `
-    <score-partwise version="3.1" xmlns="http://www.musicxml.org/ns/musicxml">
-      <part-list>
-        <score-part id="P1">
-          <part-name>Piano</part-name>
-        </score-part>
-      </part-list>
-      <part id="P1">
-        <measure number="1">
-          <attributes>
-            <divisions>1</divisions>
-          </attributes>
-          <note>
-            <pitch>
-              <step>C</step>
-              <octave>4</octave>
-            </pitch>
-            <duration>1</duration>
-          </note>
-        </measure>
-      </part>
-    </score-partwise>`;
-  const result = parseMusicXML(xml);
-  assert.strictEqual(result.tracks.length, 1);
-  assert.strictEqual(result.tracks[0].events[0].noteNumber, 60);
-  delete global.DOMParser;
-  console.log('parseMusicXML namespace OK');
-}
-
 testParseMIDI();
-testParseMusicXML();
 testAssignTrackInfo();
-testLoadMusicFileMusicXML().catch((err) => {
+testLoadMusicFileMIDI().catch((err) => {
   console.error(err);
   process.exit(1);
 });
-testParseMusicXMLNamespace();

--- a/test_staff_names.js
+++ b/test_staff_names.js
@@ -1,57 +1,63 @@
 const assert = require('assert');
-const { parseMusicXML } = require('./script.js');
-const { JSDOM } = require('jsdom');
+const { parseMIDI, assignTrackInfo } = require('./script.js');
 
-function testParseMusicXMLStaffNames() {
-  global.DOMParser = new JSDOM().window.DOMParser;
-  const xml = `
-    <score-partwise version="3.1">
-      <part-list>
-        <score-part id="P1">
-          <part-name>Ensemble</part-name>
-        </score-part>
-      </part-list>
-      <part id="P1">
-        <measure number="1">
-          <attributes>
-            <divisions>1</divisions>
-            <staff-details number="1">
-              <staff-name>Flauta</staff-name>
-            </staff-details>
-            <staff-details number="2">
-              <staff-name>Trompeta</staff-name>
-            </staff-details>
-          </attributes>
-          <note>
-            <pitch>
-              <step>C</step>
-              <octave>4</octave>
-            </pitch>
-            <duration>1</duration>
-            <staff>1</staff>
-          </note>
-          <note>
-            <pitch>
-              <step>D</step>
-              <octave>4</octave>
-            </pitch>
-            <duration>1</duration>
-            <staff>2</staff>
-          </note>
-        </measure>
-      </part>
-    </score-partwise>`;
-  const result = parseMusicXML(xml);
-  delete global.DOMParser;
-  assert.strictEqual(result.tracks.length, 2);
-  const flauta = result.tracks.find((t) => t.instrument === 'Flauta');
-  const trompeta = result.tracks.find((t) => t.instrument === 'Trompeta');
+function testParseMIDITrackNames() {
+  const header = [
+    0x4d, 0x54, 0x68, 0x64,
+    0x00, 0x00, 0x00, 0x06,
+    0x00, 0x01,
+    0x00, 0x02,
+    0x00, 0x60,
+  ];
+
+  const track1Events = [
+    0x00, 0xff, 0x03, 0x06, 0x46, 0x6c, 0x61, 0x75, 0x74, 0x61,
+    0x00, 0x90, 0x3c, 0x40,
+    0x60, 0x80, 0x3c, 0x40,
+    0x00, 0xff, 0x2f, 0x00,
+  ];
+  const track2Events = [
+    0x00, 0xff, 0x03, 0x08, 0x54, 0x72, 0x6f, 0x6d, 0x70, 0x65, 0x74, 0x61,
+    0x00, 0x90, 0x3e, 0x40,
+    0x60, 0x80, 0x3e, 0x40,
+    0x00, 0xff, 0x2f, 0x00,
+  ];
+
+  const track1Length = track1Events.length;
+  const track2Length = track2Events.length;
+  const track1Header = [
+    0x4d, 0x54, 0x72, 0x6b,
+    (track1Length >> 24) & 0xff,
+    (track1Length >> 16) & 0xff,
+    (track1Length >> 8) & 0xff,
+    track1Length & 0xff,
+  ];
+  const track2Header = [
+    0x4d, 0x54, 0x72, 0x6b,
+    (track2Length >> 24) & 0xff,
+    (track2Length >> 16) & 0xff,
+    (track2Length >> 8) & 0xff,
+    track2Length & 0xff,
+  ];
+
+  const bytes = new Uint8Array([
+    ...header,
+    ...track1Header,
+    ...track1Events,
+    ...track2Header,
+    ...track2Events,
+  ]);
+
+  const midi = parseMIDI(bytes.buffer);
+  const tracks = assignTrackInfo(midi.tracks);
+  assert.strictEqual(tracks.length, 2);
+  const flauta = tracks.find((t) => t.name === 'Flauta');
+  const trompeta = tracks.find((t) => t.name === 'Trompeta');
   assert(flauta);
   assert(trompeta);
   assert.strictEqual(flauta.family, 'Maderas de timbre "redondo"');
   assert.strictEqual(trompeta.family, 'Metales');
-  console.log('parseMusicXML staff names OK');
+  console.log('parseMIDI track names OK');
 }
 
-testParseMusicXMLStaffNames();
-
+testParseMIDITrackNames();


### PR DESCRIPTION
## Summary
- Drop MusicXML loading and parsing to support only MIDI and WAV files
- Update UI and documentation to reference MIDI-only loading
- Revise tests to cover MIDI loading and track name handling without XML

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa6a7ce42c833394baeb9ad905f6e7