### PR TITLE
feat: multi-instrument selection and bulk toggles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -194,6 +194,10 @@ input:hover {
   cursor: grab;
 }
 
+.instrument-item.selected {
+  background: #555;
+}
+
 .family-zone {
   border: 1px dashed #555;
   padding: 5px;


### PR DESCRIPTION
## Summary
- enable multi-selection in instrument assignment modal and drag groups to families
- add activate/deactivate all buttons and click-drag multi-toggle in developer instrument list
- highlight selected instruments with dedicated style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa6c3530048333aeb5b14de35a3720