### PR TITLE
Remove note fill after passing present line

### DIFF
--- a/script.js
+++ b/script.js
@@ -862,7 +862,7 @@ if (typeof document !== 'undefined') {
 
         // Opacidad variable según distancia al centro
         const strokeAlpha = computeOpacity(xStart, xEnd, canvas.width);
-        const fillAlpha = computeFillAlpha(xEnd, canvas.width) * strokeAlpha;
+        const fillAlpha = computeFillAlpha(xStart, canvas.width) * strokeAlpha;
 
         if (fillAlpha > 0) {
           offscreenCtx.save();

--- a/test_fill_alpha.js
+++ b/test_fill_alpha.js
@@ -5,9 +5,9 @@ function approx(a, b, eps = 1e-6) {
   assert(Math.abs(a - b) < eps, `${a} != ${b}`);
 }
 
-// Canvas width 800 -> center 400, fadeWidth 80
+// Canvas width 800 -> center 400
+approx(computeFillAlpha(420, 800), 1);
 approx(computeFillAlpha(400, 800), 1);
-approx(computeFillAlpha(360, 800), 0.5);
-approx(computeFillAlpha(320, 800), 0);
+approx(computeFillAlpha(399, 800), 0);
 
 console.log('Pruebas de desvanecimiento de relleno completadas');

--- a/utils.js
+++ b/utils.js
@@ -125,14 +125,10 @@ function computeOpacity(xStart, xEnd, canvasWidth) {
   return opacityScale.edge + (opacityScale.mid - opacityScale.edge) * progress;
 }
 
-// Calcula la opacidad del relleno tras pasar la línea de presente
-function computeFillAlpha(xEnd, canvasWidth) {
+// Devuelve 1 si el NOTE ON aún no cruza la línea de presente y 0 en caso contrario
+function computeFillAlpha(xStart, canvasWidth) {
   const center = canvasWidth / 2;
-  if (xEnd >= center) return 1;
-  const fadeWidth = canvasWidth * 0.1;
-  const dist = center - xEnd;
-  if (dist >= fadeWidth) return 0;
-  return 1 - dist / fadeWidth;
+  return xStart >= center ? 1 : 0;
 }
 
 // Control global para el efecto "bump"


### PR DESCRIPTION
## Summary
- Simplify fill alpha logic so notes lose color immediately after their NOTE ON crosses the present line
- Adjust rendering to apply fill only before the center line
- Update tests for new fill behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa79a9c2ec8333b40b0951b496b6be