### PR TITLE
Invert fill before present line

### DIFF
--- a/test_fill_alpha.js
+++ b/test_fill_alpha.js
@@ -6,8 +6,8 @@ function approx(a, b, eps = 1e-6) {
 }
 
 // Canvas width 800 -> center 400
-approx(computeFillAlpha(420, 800), 1);
+approx(computeFillAlpha(420, 800), 0);
 approx(computeFillAlpha(400, 800), 1);
-approx(computeFillAlpha(399, 800), 0);
+approx(computeFillAlpha(399, 800), 1);
 
 console.log('Pruebas de desvanecimiento de relleno completadas');

--- a/test_velocity_note_render.js
+++ b/test_velocity_note_render.js
@@ -72,7 +72,7 @@ const notes = [
 
 dom.window.__setTestNotes(notes);
 
-dom.window.__renderFrame(-1);
+dom.window.__renderFrame(1.1);
 
 const rects = contexts[1].rects;
 assert.strictEqual(rects.length, 4, 'Debe dibujar cuatro rectángulos (relleno y contorno)');

--- a/utils.js
+++ b/utils.js
@@ -125,10 +125,10 @@ function computeOpacity(xStart, xEnd, canvasWidth) {
   return opacityScale.edge + (opacityScale.mid - opacityScale.edge) * progress;
 }
 
-// Devuelve 1 si el NOTE ON aún no cruza la línea de presente y 0 en caso contrario
+// Devuelve 1 si el NOTE ON ya cruzó la línea de presente y 0 si aún no
 function computeFillAlpha(xStart, canvasWidth) {
   const center = canvasWidth / 2;
-  return xStart >= center ? 1 : 0;
+  return xStart > center ? 0 : 1;
 }
 
 // Control global para el efecto "bump"


### PR DESCRIPTION
## Summary
- Flip fill logic so notes are empty before reaching present line and fill on NOTE ON
- Update fill alpha and note render tests for new behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa7b4bda388333a63419e95bdec75b