### PR TITLE
Ensure glow effect scales only vertically

### DIFF
--- a/test_glow_control.js
+++ b/test_glow_control.js
@@ -24,6 +24,7 @@ const ctx = {
 
 applyGlowEffect(ctx, 'square', 0, 0, 10, 10, 0.5);
 assert(ctx.shadowBlur > 20, 'blur no escalado');
-assert(ctx.w > 10 && ctx.h > 10, 'tamaño no escalado');
+assert.strictEqual(ctx.w, 10, 'el ancho no debe cambiar');
+assert(ctx.h > 10, 'la altura debe escalarse');
 
 console.log('Pruebas de control de glow completadas');

--- a/test_visual_effects.js
+++ b/test_visual_effects.js
@@ -4,6 +4,7 @@ const {
   computeBumpHeight,
   computeGlowAlpha,
   applyGlowEffect,
+  setGlowStrength,
 } = require('./script');
 
 function approx(actual, expected, eps = 1e-6) {
@@ -28,7 +29,8 @@ approx(computeGlowAlpha(0, 0), 1); // Inicio del brillo
 approx(computeGlowAlpha(0.1, 0), 0.5); // Mitad del efecto
 approx(computeGlowAlpha(0.25, 0), 0); // Efecto terminado
 
-// Prueba para applyGlowEffect con desenfoque
+// Prueba para applyGlowEffect con desenfoque solo vertical
+setGlowStrength(1.5);
 const glowCtx = {
   shadowBlur: 0,
   shadowColor: null,
@@ -36,13 +38,18 @@ const glowCtx = {
   save() {},
   restore() {},
   beginPath() {},
-  rect() {},
+  rect(x, y, w, h) {
+    this.lastWidth = w;
+    this.lastHeight = h;
+  },
   fillCalled: false,
   fill() {
     this.fillCalled = true;
   },
 };
 applyGlowEffect(glowCtx, 'square', 0, 0, 10, 10, 0.5);
+assert.strictEqual(glowCtx.lastWidth, 10, 'el glow no debe alterar el ancho');
+assert.strictEqual(glowCtx.lastHeight, 15, 'el glow debe escalar solo la altura');
 assert(glowCtx.shadowBlur > 0, 'shadowBlur no aplicado');
 assert.strictEqual(glowCtx.fillStyle, '#ffffff');
 assert(glowCtx.fillCalled, 'fill no llamado en glow');

--- a/utils.js
+++ b/utils.js
@@ -226,9 +226,9 @@ function applyGlowEffect(ctx, shape, x, y, width, height, alpha) {
   ctx.shadowBlur = 20 * glowStrength;
   ctx.shadowColor = '#ffffff';
   ctx.fillStyle = '#ffffff';
-  const w = width * glowStrength;
+  const w = width;
   const h = height * glowStrength;
-  const offsetX = x - (w - width) / 2;
+  const offsetX = x;
   const offsetY = y - (h - height) / 2;
   drawNoteShape(ctx, shape, offsetX, offsetY, w, h);
   ctx.restore();


### PR DESCRIPTION
## Summary
- Keep glow effect vertical-only so note width always reflects duration
- Test glow rendering to confirm unchanged width and vertical scaling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa7d6a127c833387b297131452f91c