### PR TITLE
Fix FPS loop and stroke opacity

### DIFF
--- a/script.js
+++ b/script.js
@@ -81,10 +81,17 @@ if (typeof document !== 'undefined') {
 
     const canvas = document.getElementById('visualizer');
     const ctx = canvas.getContext('2d');
+    ctx.imageSmoothingEnabled = false;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    canvas.style.imageRendering = 'pixelated';
 
     // Canvas offscreen para optimizar el renderizado de notas
     const offscreenCanvas = document.createElement('canvas');
     const offscreenCtx = offscreenCanvas.getContext('2d');
+    offscreenCtx.imageSmoothingEnabled = false;
+    offscreenCtx.lineCap = 'round';
+    offscreenCtx.lineJoin = 'round';
     offscreenCanvas.width = canvas.width;
     offscreenCanvas.height = canvas.height;
 
@@ -860,9 +867,10 @@ if (typeof document !== 'undefined') {
           canvas.height - (clamped - NOTE_MIN + 1) * noteHeight -
           (height - noteHeight) / 2;
 
-        // Opacidad variable según distancia al centro
-        const strokeAlpha = computeOpacity(xStart, xEnd, canvas.width);
-        const fillAlpha = computeFillAlpha(xStart, canvas.width) * strokeAlpha;
+        // Opacidad progresiva y relleno solo tras la línea de presente
+        const baseAlpha = computeOpacity(xStart, xEnd, canvas.width);
+        const fillAlpha = computeFillAlpha(xStart, canvas.width) * baseAlpha;
+        const strokeAlpha = fillAlpha;
 
         if (fillAlpha > 0) {
           offscreenCtx.save();

--- a/test_fixed_fps.js
+++ b/test_fixed_fps.js
@@ -3,11 +3,17 @@ const { startFixedFPSLoop } = require('./script');
 
 const origSetInterval = global.setInterval;
 const origClearInterval = global.clearInterval;
+const origRAF = global.requestAnimationFrame;
 let capturedDelay = null;
 let cleared = false;
 
+global.requestAnimationFrame = () => {
+  throw new Error('requestAnimationFrame should not be used');
+};
+
 global.setInterval = (fn, delay) => {
   capturedDelay = delay;
+  fn();
   return 1;
 };
 global.clearInterval = (id) => {
@@ -21,5 +27,6 @@ assert(cleared);
 
 global.setInterval = origSetInterval;
 global.clearInterval = origClearInterval;
+global.requestAnimationFrame = origRAF;
 
 console.log('Pruebas de FPS constantes completadas');

--- a/utils.js
+++ b/utils.js
@@ -407,16 +407,11 @@ function canStartPlayback(audioBuffer, notes) {
   return !!(audioBuffer || (Array.isArray(notes) && notes.length > 0));
 }
 
-// Inicia un bucle de animación a fps constantes utilizando setInterval y rAF
+// Inicia un bucle de animación a fps constantes utilizando setInterval
+// Se evita depender de requestAnimationFrame para garantizar 60 fps fijos
 function startFixedFPSLoop(callback, fps = 60) {
   const interval = 1000 / fps;
-  const id = setInterval(() => {
-    if (typeof requestAnimationFrame !== 'undefined') {
-      requestAnimationFrame(callback);
-    } else {
-      callback();
-    }
-  }, interval);
+  const id = setInterval(callback, interval);
   return () => clearInterval(id);
 }
 


### PR DESCRIPTION
## Summary
- ensure fixed 60 FPS loop decoupled from display refresh
- disable canvas smoothing and round line edges for crisp rendering
- apply progressive opacity to note outlines and test FPS behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa7fe43f20833392b4b3f75b831f15