### PR TITLE
chore: plan de optimizacion de renderizado

### DIFF
--- a/agents_renderizado.md
+++ b/agents_renderizado.md
@@ -1,0 +1,57 @@
+# Plan de optimización de renderizado MIDI
+
+## Objetivo
+Mantener una visualización fluida de notas MIDI a 60fps o más, incluso en pantalla completa con supersampling, sin alterar la estructura de la UI existente.
+
+## Estrategia
+1. **Estado y cola de eventos**
+   - Mantener un mapa `activeNotes` con los datos de cada nota activa (nota, velocidad, tiempo de inicio y fin).
+   - Los handlers de MIDI (`noteon`, `noteoff`) solo encolan operaciones en `eventQueue`, colapsando ráfagas repetidas.
+   - La cola se procesa únicamente dentro del `requestAnimationFrame`.
+
+2. **Bucle de render único**
+   - Implementar `renderLoop(t)` usando `performance.now()` para calcular `dt`.
+   - Restringir `dt` entre 8 ms y 32 ms para evitar saltos bruscos.
+   - Todas las animaciones, desplazamientos y decaimientos deben basarse en el tiempo (`time-based`).
+
+3. **Batching y límite de operaciones**
+   - Procesar la cola en batch, con un máximo de ~200 operaciones por frame para evitar bloqueos.
+   - Reutilizar objetos y arrays (object pooling) para minimizar la generación de basura y pausas de GC.
+
+4. **Supersampling adaptable**
+   - Calcular la resolución interna como `canvasCSS * devicePixelRatio * S`.
+   - Iniciar con `S = 1.25` y ajustar dinámicamente según el rendimiento.
+   - Si los frames superan 18 ms, reducir `S` o el límite de operaciones; si son menores a 12 ms, aumentar gradualmente `S` hasta un máximo permitido.
+
+5. **Pantalla completa y cambios de tamaño**
+   - Utilizar la Fullscreen API para entrar/salir de pantalla completa y ocultar el cursor.
+   - Emplear `ResizeObserver` y detectar cambios de `devicePixelRatio` para recalcular dimensiones y matrices una vez por frame.
+   - Alinear a píxel las líneas críticas para evitar parpadeos.
+
+6. **Animaciones basadas en GPU**
+   - Usar solo `transform` y `opacity` para la animación de elementos DOM, aplicando `will-change: transform, opacity` y `contain: paint` en contenedores masivos.
+   - Evitar `top/left/width/height` y lecturas forzadas de layout en el mismo frame.
+
+7. **Compatibilidad con `prefers-reduced-motion`**
+   - Detectar la media query y, si está activa, sustituir las interpolaciones suaves por actualizaciones discretas sin animación continua.
+
+8. **Detección de fallbacks**
+   - Priorizar WebGL con MSAA u offscreen framebuffer.
+   - Si no está disponible, usar Canvas2D con supersampling.
+   - Ajustar el factor de supersampling a valores bajos en dispositivos débiles.
+
+## Tareas
+- [ ] Crear estructura de estado central y cola de eventos para `noteOn`/`noteOff`.
+- [ ] Implementar bucle `requestAnimationFrame` único con cálculo de `dt` y clamping.
+- [ ] Procesar eventos en batch con límite configurable por frame.
+- [ ] Adaptar el renderizado de notas a un sistema `time-based`.
+- [ ] Convertir ticks a tiempo usando el tempo map del MIDI para evitar asumir un BPM constante.
+- [ ] Incorporar supersampling basado en `devicePixelRatio` y factor dinámico `S`.
+- [ ] Ajustar la lógica de pantalla completa y redimensionamiento con `ResizeObserver`.
+- [ ] Añadir autoajuste de supersampling según tiempos de frame.
+- [ ] Implementar soporte para `prefers-reduced-motion`.
+- [ ] Establecer mecanismos de pooling para objetos/arrays reutilizables.
+- [ ] Optimizar handlers MIDI para solo encolar eventos y colapsar ráfagas.
+- [ ] Asegurar animaciones basadas en `transform`/`opacity` con `will-change` y `contain`.
+- [ ] Detectar cambios de `devicePixelRatio` para recalcular resoluciones.
+- [ ] Implementar fallback a Canvas2D cuando no haya WebGL/MSAA.

--- a/agents_tareas
+++ b/agents_tareas
@@ -97,3 +97,15 @@
 96. [x] Cambiar la figura triángulo alargado por un diamante alargado con lados rectos.
 97. [x] Ocultar el puntero del mouse al activar el modo de pantalla completa.
 98. [x] Actualizar las pruebas unitarias para el diamante alargado.
+99. [ ] Reestructurar eventos MIDI para que solo actualicen estado interno y encolen operaciones.
+100. [ ] Crear único bucle `requestAnimationFrame` con cálculo de `dt` (8-32 ms) y renderizado basado en tiempo.
+101. [ ] Procesar la cola de eventos en batch, limitando el número de operaciones por frame.
+102. [ ] Implementar supersampling dinámico basado en `devicePixelRatio` y un factor ajustable.
+103. [ ] Integrar la Fullscreen API, recalculando resoluciones y ocultando el cursor.
+104. [ ] Detectar cambios de tamaño y DPR con `ResizeObserver` y actualizar las dimensiones una vez por frame.
+105. [ ] Soportar `prefers-reduced-motion` desactivando interpolaciones continuas.
+106. [ ] Ajustar automáticamente el factor de supersampling u operaciones según el tiempo de frame (12–18 ms).
+107. [ ] Optimizar animaciones utilizando solo `transform` y `opacity`, aplicando `will-change` y `contain`.
+108. [ ] Reutilizar objetos y arrays para minimizar pausas de GC.
+109. [ ] Coalescer ráfagas de eventos MIDI para evitar saturar la cola.
+110. [ ] Proveer fallback de renderizado a Canvas2D cuando WebGL/MSAA no esté disponible.


### PR DESCRIPTION
## Summary
- add render optimization plan for MIDI viewer
- clarify tempo map usage in render tasks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa85f2d7308333b4e91cb974d19495