### PR TITLE
feat: add adaptive supersampling

### DIFF
--- a/agents_renderizado.md
+++ b/agents_renderizado.md
@@ -46,9 +46,9 @@ Mantener una visualización fluida de notas MIDI a 60fps o más, incluso en pant
 - [x] Procesar eventos en batch con límite configurable por frame.
 - [x] Adaptar el renderizado de notas a un sistema `time-based`.
 - [x] Convertir ticks a tiempo usando el tempo map del MIDI para evitar asumir un BPM constante.
-- [ ] Incorporar supersampling basado en `devicePixelRatio` y factor dinámico `S`.
-- [ ] Ajustar la lógica de pantalla completa y redimensionamiento con `ResizeObserver`.
-- [ ] Añadir autoajuste de supersampling según tiempos de frame.
+- [x] Incorporar supersampling basado en `devicePixelRatio` y factor dinámico `S`.
+- [x] Ajustar la lógica de pantalla completa y redimensionamiento con `ResizeObserver`.
+- [x] Añadir autoajuste de supersampling según tiempos de frame.
 - [x] Implementar soporte para `prefers-reduced-motion`.
 - [ ] Establecer mecanismos de pooling para objetos/arrays reutilizables.
 - [ ] Optimizar handlers MIDI para solo encolar eventos y colapsar ráfagas.

--- a/utils.js
+++ b/utils.js
@@ -358,7 +358,8 @@ function calculateCanvasSize(
   fullScreen = false,
   viewportWidth = 0,
   viewportHeight = 0,
-  dpr = 1
+  dpr = 1,
+  superSampling = 1
 ) {
   const ratio = aspect === '9:16' ? 9 / 16 : 16 / 9;
   let styleWidth;
@@ -377,8 +378,8 @@ function calculateCanvasSize(
     styleHeight = Math.round(height);
   }
   return {
-    width: Math.round(styleWidth * dpr),
-    height: Math.round(styleHeight * dpr),
+    width: Math.round(styleWidth * dpr * superSampling),
+    height: Math.round(styleHeight * dpr * superSampling),
     styleWidth,
     styleHeight,
   };
@@ -414,11 +415,17 @@ function prefersReducedMotion() {
 // evitando animaciones continuas
 function startFixedFPSLoop(callback, fps = 60) {
   if (prefersReducedMotion()) {
-    callback();
+    callback(0, performance.now());
     return () => {};
   }
   const interval = 1000 / fps;
-  const id = setInterval(callback, interval);
+  let last = performance.now();
+  const id = setInterval(() => {
+    const now = performance.now();
+    const dt = Math.min(Math.max(now - last, 8), 32);
+    last = now;
+    callback(dt, now);
+  }, interval);
   return () => clearInterval(id);
 }
 


### PR DESCRIPTION
## Summary
- add supersampling factor tied to device pixel ratio with adaptive adjustments
- resize canvas with ResizeObserver and DPI change detection
- expose frame time in fixed FPS loop for runtime supersampling tuning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa8c3073d08333aa63e5996845c970