### PR TITLE
Add Cornos family and optimize note rendering

### DIFF
--- a/test_instrument_accents.js
+++ b/test_instrument_accents.js
@@ -11,10 +11,10 @@ const tracks = assignTrackInfo([
 assert.strictEqual(tracks[0].instrument, 'Saxofón');
 assert.strictEqual(tracks[0].family, 'Saxofones');
 assert.strictEqual(tracks[1].instrument, 'Corno francés');
-assert.strictEqual(tracks[1].family, 'Metales');
+assert.strictEqual(tracks[1].family, 'Cornos');
 assert.strictEqual(tracks[2].instrument, 'Saxofón');
 assert.strictEqual(tracks[2].family, 'Saxofones');
 assert.strictEqual(tracks[3].instrument, 'Corno francés');
-assert.strictEqual(tracks[3].family, 'Metales');
+assert.strictEqual(tracks[3].family, 'Cornos');
 
 console.log('Pruebas de reconocimiento de tildes completadas');

--- a/test_instrument_numbers.js
+++ b/test_instrument_numbers.js
@@ -12,6 +12,6 @@ assert.strictEqual(tracks[0].family, 'Maderas de timbre "redondo"');
 assert.strictEqual(tracks[1].instrument, 'Clarinete');
 assert.strictEqual(tracks[1].family, 'Dobles cañas');
 assert.strictEqual(tracks[2].instrument, 'Corno francés');
-assert.strictEqual(tracks[2].family, 'Metales');
+assert.strictEqual(tracks[2].family, 'Cornos');
 
 console.log('Pruebas de reconocimiento de numeración de instrumentos completadas');


### PR DESCRIPTION
## Summary
- add "Cornos" family with yellow capsule default
- map corno francés to new family
- render only notes within view to improve animation smoothness

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab2be9f87083339afba07b3e2be508