### PR TITLE
Add Cornos family to UI and configuration

### DIFF
--- a/configuracion.js
+++ b/configuracion.js
@@ -15,10 +15,10 @@ window.DEFAULT_CONFIG = {
     "Saxofón alto": "Saxofones",
     "Saxofón tenor": "Saxofones",
     "Saxofón barítono": "Saxofones",
-    "Corno francés (Sol) 1": "Metales",
-    "Corno francés (Sol) 2": "Metales",
-    "Corno francés (Sol) 3": "Metales",
-    "Corno francés (Sol) 4": "Metales",
+      "Corno francés (Sol) 1": "Cornos",
+      "Corno francés (Sol) 2": "Cornos",
+      "Corno francés (Sol) 3": "Cornos",
+      "Corno francés (Sol) 4": "Cornos",
     "Trompeta (Si Bemol) 1": "Metales",
     "Trompeta (Si Bemol) 2": "Metales",
     "Trompeta (Si Bemol) 3": "Metales",
@@ -42,6 +42,12 @@ window.DEFAULT_CONFIG = {
   },
   "familyCustomizations": {
     "Metales": {
+      "color": "#ffb900",
+      "shape": "capsule",
+      "colorBright": "#ffea00",
+      "colorDark": "#ff8800"
+    },
+    "Cornos": {
       "color": "#ffb900",
       "shape": "capsule",
       "colorBright": "#ffea00",

--- a/configuracion.json
+++ b/configuracion.json
@@ -15,10 +15,10 @@
     "Saxofón alto": "Saxofones",
     "Saxofón tenor": "Saxofones",
     "Saxofón barítono": "Saxofones",
-    "Corno francés (Sol) 1": "Metales",
-    "Corno francés (Sol) 2": "Metales",
-    "Corno francés (Sol) 3": "Metales",
-    "Corno francés (Sol) 4": "Metales",
+      "Corno francés (Sol) 1": "Cornos",
+      "Corno francés (Sol) 2": "Cornos",
+      "Corno francés (Sol) 3": "Cornos",
+      "Corno francés (Sol) 4": "Cornos",
     "Trompeta (Si Bemol) 1": "Metales",
     "Trompeta (Si Bemol) 2": "Metales",
     "Trompeta (Si Bemol) 3": "Metales",
@@ -42,6 +42,12 @@
   },
   "familyCustomizations": {
     "Metales": {
+      "color": "#ffb900",
+      "shape": "capsule",
+      "colorBright": "#ffea00",
+      "colorDark": "#ff8800"
+    },
+    "Cornos": {
       "color": "#ffb900",
       "shape": "capsule",
       "colorBright": "#ffea00",

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
       <option>Dobles cañas</option>
       <option>Saxofones</option>
       <option>Metales</option>
+      <option>Cornos</option>
       <option>Percusión menor</option>
       <option>Tambores</option>
       <option>Platillos</option>

--- a/script.js
+++ b/script.js
@@ -1259,6 +1259,7 @@ const FAMILY_LIST = [
   'Dobles cañas',
   'Saxofones',
   'Metales',
+  'Cornos',
   'Percusión menor',
   'Tambores',
   'Platillos',


### PR DESCRIPTION
## Summary
- Include Cornos option in bottom family selector
- Expose Cornos in `FAMILY_LIST` and default mappings
- Map French horn tracks to Cornos in default configuration with color/shape presets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab2da5a50c83338fe971ee45a09bf7