### PR TITLE
Fix restart button when playback stopped

### DIFF
--- a/script.js
+++ b/script.js
@@ -1044,8 +1044,9 @@ if (typeof document !== 'undefined') {
       onRestart: () => {
         const wasPlaying = audioPlayer.isPlaying();
         audioPlayer.stop(false);
+        audioPlayer.resetStartOffset();
         stopAnimation();
-        renderFrame(audioPlayer.getStartOffset());
+        renderFrame(0);
         if (wasPlaying) startPlayback();
       },
       onAspect169: () => {

--- a/test_playback_controls.js
+++ b/test_playback_controls.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const { computeSeekOffset, resetStartOffset } = require('./script');
+const { createAudioPlayer } = require('./audioPlayer.js');
 
 // Pruebas para computeSeekOffset
 assert.strictEqual(computeSeekOffset(0, 3, 10, 0), 3); // adelantar dentro del rango
@@ -9,6 +10,31 @@ assert.strictEqual(computeSeekOffset(5, 5, 10, 2), 8); // límite considerando t
 
 // Prueba para resetStartOffset
 assert.strictEqual(resetStartOffset(), 0);
+
+// Prueba para reiniciar cuando la reproducción está detenida
+const mockCtx = {
+  currentTime: 0,
+  state: 'running',
+  destination: {},
+  resume() {
+    this.state = 'running';
+    return Promise.resolve();
+  },
+  createBufferSource() {
+    return {
+      connect() {},
+      start() {},
+      stop() {},
+    };
+  },
+};
+const player = createAudioPlayer({ createContext: () => mockCtx });
+player.loadBuffer({ duration: 10 }, 0);
+player.seek(5, 10, 0);
+player.stop(false);
+assert.strictEqual(player.getStartOffset(), 5);
+player.resetStartOffset();
+assert.strictEqual(player.getStartOffset(), 0);
 
 console.log('Pruebas de controles de reproducción completadas');
 


### PR DESCRIPTION
## Summary
- Reset start offset when clicking Inicio regardless of playback state
- Test restart behavior to ensure offset resets when stopped

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aba0533e4c8333bfc3dea87809ac12