### PR TITLE
Mejora tooltips y controles de FPS

### DIFF
--- a/help.js
+++ b/help.js
@@ -1,20 +1,25 @@
-function setupHelpMessages(devMode) {
-  const details = [];
+function setupHelpMessages() {
+  const tooltip = document.createElement('div');
+  tooltip.className = 'tooltip hidden';
+  document.body.appendChild(tooltip);
+
   document.querySelectorAll('[data-help]').forEach((el) => {
     const text = el.getAttribute('data-help');
     if (!text) return;
-    const detail = document.createElement('div');
-    detail.className = 'help-detail hidden';
-    detail.textContent = text;
-    el.insertAdjacentElement('afterend', detail);
-    details.push(detail);
+
+    el.addEventListener('mouseenter', () => {
+      tooltip.textContent = text;
+      const rect = el.getBoundingClientRect();
+      const win = typeof window !== 'undefined' ? window : { scrollX: 0, scrollY: 0 };
+      tooltip.style.left = `${rect.left + win.scrollX}px`;
+      tooltip.style.top = `${rect.bottom + win.scrollY + 5}px`;
+      tooltip.classList.remove('hidden');
+    });
+
+    el.addEventListener('mouseleave', () => {
+      tooltip.classList.add('hidden');
+    });
   });
-  const update = () => {
-    const show = devMode.isActive();
-    details.forEach((d) => d.classList.toggle('hidden', !show));
-  };
-  devMode.button.addEventListener('click', update);
-  update();
 }
 
 if (typeof module !== 'undefined') {

--- a/index.html
+++ b/index.html
@@ -58,7 +58,8 @@
       id="toggle-fps"
       title="Alternar modo de FPS"
       data-help="Alterna entre un FPS fijo y la tasa automática según la pantalla."
-    >FPS Auto</button>
+      class="active"
+    >FPS Fijo</button>
   </nav>
 
   <canvas

--- a/script.js
+++ b/script.js
@@ -511,13 +511,13 @@ if (typeof document !== 'undefined') {
 
       // Control para ventana mínima y máxima de ms
       const minLabel = document.createElement('label');
-      minLabel.textContent = 'Mín dt (ms):';
+      minLabel.textContent = 'Mín Δt (ms):';
       const minInput = document.createElement('input');
       minInput.type = 'number';
       minInput.min = '0';
       minInput.value = minFrameMs;
       const maxLabel = document.createElement('label');
-      maxLabel.textContent = 'Máx dt (ms):';
+      maxLabel.textContent = 'Máx Δt (ms):';
       const maxInput = document.createElement('input');
       maxInput.type = 'number';
       maxInput.min = '0';
@@ -540,14 +540,14 @@ if (typeof document !== 'undefined') {
       minItem.appendChild(minLabel);
       minItem.appendChild(minInput);
       minItem.dataset.help =
-        'Tiempo mínimo entre frames usado en el modo automático.';
+        'Tiempo mínimo entre cuadros en milisegundos (inverso de los FPS) usado en el modo automático.';
       developerControls.appendChild(minItem);
       const maxItem = document.createElement('div');
       maxItem.className = 'dev-control';
       maxItem.appendChild(maxLabel);
       maxItem.appendChild(maxInput);
       maxItem.dataset.help =
-        'Tiempo máximo entre frames usado en el modo automático.';
+        'Tiempo máximo entre cuadros en milisegundos (inverso de los FPS) usado en el modo automático.';
       developerControls.appendChild(maxItem);
 
       // Control para supersampling inicial
@@ -573,10 +573,9 @@ if (typeof document !== 'undefined') {
       ssItem.dataset.help =
         'Factor de supersampling inicial aplicado al canvas.';
       developerControls.appendChild(ssItem);
-      // Ejecuta la inicialización de mensajes de ayuda usando el alias local
-      // para evitar conflictos de nombres globales.
-      initHelpMessages(devMode);
     }
+    // Inicializa los mensajes de ayuda flotantes
+    initHelpMessages();
 
     let currentTracks = [];
     let notes = [];
@@ -1149,14 +1148,16 @@ if (typeof document !== 'undefined') {
           startAnimation();
         }
         if (uiControls.toggleFPSBtn) {
-          uiControls.toggleFPSBtn.textContent = getFPSMode()
-            ? 'FPS Auto'
-            : 'FPS Fijo';
+          const fixed = getFPSMode();
+          uiControls.toggleFPSBtn.textContent = fixed ? 'FPS Fijo' : 'FPS Auto';
+          uiControls.toggleFPSBtn.classList.toggle('active', fixed);
         }
       },
     });
     if (uiControls.toggleFPSBtn) {
-      uiControls.toggleFPSBtn.textContent = 'FPS Auto';
+      const fixed = getFPSMode();
+      uiControls.toggleFPSBtn.textContent = fixed ? 'FPS Fijo' : 'FPS Auto';
+      uiControls.toggleFPSBtn.classList.toggle('active', fixed);
     }
     document.addEventListener('keydown', (e) => {
       if (e.code === 'Space') {

--- a/styles.css
+++ b/styles.css
@@ -212,8 +212,18 @@ input:hover {
   display: none;
 }
 
-.help-detail {
+.tooltip {
+  position: absolute;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
   font-size: 0.8em;
-  color: #ccc;
-  margin-top: 2px;
+  pointer-events: none;
+  z-index: 1000;
+}
+
+#toggle-fps.active {
+  background-color: #444;
+  color: #fff;
 }

--- a/test_help_messages.js
+++ b/test_help_messages.js
@@ -1,31 +1,26 @@
 const assert = require('assert');
 const { JSDOM } = require('jsdom');
-const { initializeDeveloperMode } = require('./ui');
 const { setupHelpMessages } = require('./help');
 
 const dom = new JSDOM(`<!DOCTYPE html><html><body>
-<button id="dev-btn" data-help="Activa modo desarrollador"></button>
-<div id="panel" class="hidden"></div>
 <button id="play" title="Play" data-help="Reproduce la animación"></button>
 </body></html>`);
 
 global.document = dom.window.document;
 
-const devMode = initializeDeveloperMode({
-  button: document.getElementById('dev-btn'),
-  panel: document.getElementById('panel'),
-});
+setupHelpMessages();
 
-setupHelpMessages(devMode);
+const tooltip = document.querySelector('.tooltip');
+assert(tooltip, 'tooltip element should exist');
+assert(tooltip.classList.contains('hidden'));
 
-const helpDetail = document.querySelector('#play + .help-detail');
-assert(helpDetail, 'help detail element should exist');
-assert(helpDetail.classList.contains('hidden'));
+const playBtn = document.getElementById('play');
+playBtn.dispatchEvent(new dom.window.Event('mouseenter'));
+assert.strictEqual(tooltip.classList.contains('hidden'), false);
+assert.strictEqual(tooltip.textContent, 'Reproduce la animación');
 
-document.getElementById('dev-btn').click();
-assert.strictEqual(helpDetail.classList.contains('hidden'), false);
-
-document.getElementById('dev-btn').click();
-assert.strictEqual(helpDetail.classList.contains('hidden'), true);
+playBtn.dispatchEvent(new dom.window.Event('mouseleave'));
+assert(tooltip.classList.contains('hidden'));
 
 console.log('Pruebas de mensajes de ayuda completadas');
+


### PR DESCRIPTION
## Resumen
- Implementa tooltips flotantes que aparecen al pasar el cursor por elementos con `data-help`.
- Aclara el significado de “Mín/Máx Δt (ms)” indicando su relación con los FPS.
- Actualiza el botón de alternancia de FPS para mostrar el modo activo y resaltar el estado fijo.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abb05559d88333a8a09db1d93defb8