### PR TITLE
feat: enhance midi learn tempo range

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,29 @@
         value="0.01"
       />
     </label>
+    <label
+      id="tempo-range-label"
+      title="Rango de tempo"
+      data-help="Define los porcentajes mínimo y máximo que puede ajustar el control MIDI."
+    >
+      Rango
+      <input
+        type="number"
+        id="tempo-min"
+        min="10"
+        max="100"
+        step="1"
+        value="10"
+      />
+      <input
+        type="number"
+        id="tempo-max"
+        min="100"
+        max="400"
+        step="10"
+        value="400"
+      />
+    </label>
   </nav>
 
   <canvas

--- a/script.js
+++ b/script.js
@@ -118,6 +118,8 @@ let tempoSensitivity = 0.01;
 let midiLearnMode = false;
 let midiBinding = null;
 let lastMidiValue = 0;
+let tempoMinMultiplier = 0.1;
+let tempoMaxMultiplier = 4;
 
 function startMidiLearn() {
   midiLearnMode = true;
@@ -130,6 +132,28 @@ function setTempoSensitivity(val) {
 
 function getTempoMultiplier() {
   return tempoMultiplier;
+}
+
+function setTempoRange(min, max) {
+  const minVal = parseFloat(min);
+  const maxVal = parseFloat(max);
+  if (
+    !isNaN(minVal) &&
+    !isNaN(maxVal) &&
+    minVal > 0 &&
+    maxVal >= minVal
+  ) {
+    tempoMinMultiplier = minVal;
+    tempoMaxMultiplier = maxVal;
+    tempoMultiplier = Math.min(
+      tempoMaxMultiplier,
+      Math.max(tempoMinMultiplier, tempoMultiplier)
+    );
+  }
+}
+
+function getTempoRange() {
+  return { min: tempoMinMultiplier, max: tempoMaxMultiplier };
 }
 
 function handleMIDIMessage(event) {
@@ -147,7 +171,10 @@ function handleMIDIMessage(event) {
       midiBinding.channel === channel
     ) {
       const delta = (data2 - lastMidiValue) * tempoSensitivity;
-      tempoMultiplier = Math.min(4, Math.max(0.1, tempoMultiplier + delta));
+      tempoMultiplier = Math.min(
+        tempoMaxMultiplier,
+        Math.max(tempoMinMultiplier, tempoMultiplier + delta)
+      );
       lastMidiValue = data2;
     }
   }
@@ -1269,6 +1296,7 @@ if (typeof document !== 'undefined') {
       },
       onMidiLearn: () => startMidiLearn(),
       onSensitivityChange: (val) => setTempoSensitivity(val),
+      onRangeChange: (min, max) => setTempoRange(min, max),
     });
     if (uiControls.toggleFPSBtn) {
       const fixed = getFPSMode();
@@ -2017,6 +2045,8 @@ if (typeof module !== 'undefined') {
     startMidiLearn,
     setTempoSensitivity,
     getTempoMultiplier,
+    setTempoRange,
+    getTempoRange,
     handleMIDIMessage,
   };
 }

--- a/test_midi_learn.js
+++ b/test_midi_learn.js
@@ -4,16 +4,20 @@ const {
   setTempoSensitivity,
   getTempoMultiplier,
   handleMIDIMessage,
+  setTempoRange,
 } = require('./script.js');
 
 // Simula la asignación de un control MIDI
 startMidiLearn();
 handleMIDIMessage({ data: [0xb0, 10, 64] });
-// Ajusta sensibilidad y prueba variaciones
+// Ajusta sensibilidad y rango de tempo
 setTempoSensitivity(0.02);
-handleMIDIMessage({ data: [0xb0, 10, 65] });
-assert.ok(Math.abs(getTempoMultiplier() - 1.02) < 1e-6);
-handleMIDIMessage({ data: [0xb0, 10, 63] });
-assert.ok(Math.abs(getTempoMultiplier() - 0.98) < 1e-6);
+setTempoRange(0.5, 1.5);
+// Incrementa dentro del rango
+handleMIDIMessage({ data: [0xb0, 10, 127] });
+assert.ok(Math.abs(getTempoMultiplier() - 1.5) < 1e-6);
+// Intenta disminuir por debajo del mínimo permitido
+handleMIDIMessage({ data: [0xb0, 10, 0] });
+assert.ok(Math.abs(getTempoMultiplier() - 0.5) < 1e-6);
 
 console.log('Pruebas de MIDI Learn completadas');

--- a/ui.js
+++ b/ui.js
@@ -14,6 +14,7 @@ function initializeUI({
   onToggleFPS,
   onMidiLearn,
   onSensitivityChange,
+  onRangeChange,
 }) {
   const playBtn = document.getElementById('play-stop');
   const forwardBtn = document.getElementById('seek-forward');
@@ -25,6 +26,8 @@ function initializeUI({
   const toggleFPSBtn = document.getElementById('toggle-fps');
   const midiLearnBtn = document.getElementById('midi-learn');
   const tempoSensitivityInput = document.getElementById('tempo-sensitivity');
+  const tempoMinInput = document.getElementById('tempo-min');
+  const tempoMaxInput = document.getElementById('tempo-max');
 
   playBtn.addEventListener('click', () => {
     if (isPlaying()) {
@@ -51,6 +54,15 @@ function initializeUI({
       onSensitivityChange(e.target.value)
     );
   }
+  if (tempoMinInput && tempoMaxInput && onRangeChange) {
+    const handler = () =>
+      onRangeChange(
+        parseFloat(tempoMinInput.value) / 100,
+        parseFloat(tempoMaxInput.value) / 100
+      );
+    tempoMinInput.addEventListener('input', handler);
+    tempoMaxInput.addEventListener('input', handler);
+  }
 
   return {
     playBtn,
@@ -63,6 +75,8 @@ function initializeUI({
     toggleFPSBtn,
     midiLearnBtn,
     tempoSensitivityInput,
+    tempoMinInput,
+    tempoMaxInput,
   };
 }
 


### PR DESCRIPTION
## Summary
- prevent MIDI Learn tempo control from reversing or stopping playback
- add UI control to set tempo percentage range for MIDI Learn
- expose API and tests for adjustable tempo range

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae99a7c760833380e9e5766ed6e90d