### PR TITLE
Refactor MIDI tempo control to BPM range

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,24 +79,16 @@
     <label
       id="tempo-range-label"
       title="Rango de tempo"
-      data-help="Define los porcentajes mínimo y máximo que puede ajustar el control MIDI."
+      data-help="Define el rango en BPM alrededor del tempo base que puede ajustar el control MIDI."
     >
-      Rango
+      Rango BPM
       <input
         type="number"
-        id="tempo-min"
-        min="10"
+        id="tempo-range"
+        min="1"
         max="100"
         step="1"
-        value="10"
-      />
-      <input
-        type="number"
-        id="tempo-max"
-        min="100"
-        max="400"
-        step="10"
-        value="400"
+        value="20"
       />
     </label>
   </nav>

--- a/test_midi_learn.js
+++ b/test_midi_learn.js
@@ -1,23 +1,24 @@
 const assert = require('assert');
 const {
   startMidiLearn,
-  setTempoSensitivity,
   getTempoMultiplier,
   handleMIDIMessage,
-  setTempoRange,
+  setTempoRangeBPM,
+  setBaseBpm,
 } = require('./script.js');
 
 // Simula la asignación de un control MIDI
 startMidiLearn();
 handleMIDIMessage({ data: [0xb0, 10, 64] });
-// Ajusta sensibilidad y rango de tempo
-setTempoSensitivity(0.02);
-setTempoRange(0.5, 1.5);
-// Incrementa dentro del rango
+// Define BPM base y rango
+setBaseBpm(120);
+setTempoRangeBPM(20);
+// Incrementa dentro del rango (120 + 10)
 handleMIDIMessage({ data: [0xb0, 10, 127] });
-assert.ok(Math.abs(getTempoMultiplier() - 1.5) < 1e-6);
-// Intenta disminuir por debajo del mínimo permitido
+assert.ok(Math.abs(getTempoMultiplier() - 130 / 120) < 1e-6);
+// Intenta disminuir por debajo del mínimo permitido (no menos de 10% debajo del base)
+setTempoRangeBPM(40);
 handleMIDIMessage({ data: [0xb0, 10, 0] });
-assert.ok(Math.abs(getTempoMultiplier() - 0.5) < 1e-6);
+assert.ok(Math.abs(getTempoMultiplier() - 0.9) < 1e-6);
 
 console.log('Pruebas de MIDI Learn completadas');

--- a/ui.js
+++ b/ui.js
@@ -26,8 +26,7 @@ function initializeUI({
   const toggleFPSBtn = document.getElementById('toggle-fps');
   const midiLearnBtn = document.getElementById('midi-learn');
   const tempoSensitivityInput = document.getElementById('tempo-sensitivity');
-  const tempoMinInput = document.getElementById('tempo-min');
-  const tempoMaxInput = document.getElementById('tempo-max');
+  const tempoRangeInput = document.getElementById('tempo-range');
 
   playBtn.addEventListener('click', () => {
     if (isPlaying()) {
@@ -54,14 +53,10 @@ function initializeUI({
       onSensitivityChange(e.target.value)
     );
   }
-  if (tempoMinInput && tempoMaxInput && onRangeChange) {
-    const handler = () =>
-      onRangeChange(
-        parseFloat(tempoMinInput.value) / 100,
-        parseFloat(tempoMaxInput.value) / 100
-      );
-    tempoMinInput.addEventListener('input', handler);
-    tempoMaxInput.addEventListener('input', handler);
+  if (tempoRangeInput && onRangeChange) {
+    tempoRangeInput.addEventListener('input', (e) =>
+      onRangeChange(parseFloat(e.target.value))
+    );
   }
 
   return {
@@ -75,8 +70,7 @@ function initializeUI({
     toggleFPSBtn,
     midiLearnBtn,
     tempoSensitivityInput,
-    tempoMinInput,
-    tempoMaxInput,
+    tempoRangeInput,
   };
 }
 


### PR DESCRIPTION
## Summary
- Convert MIDI tempo control to BPM-based range with 10% minimum limit
- Clamp playback time to avoid rewinding before last note
- Replace min/max percentage inputs with single BPM range control

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae9be897e08333b9f55834d50f7529