### PR TITLE
Persist tempo offset from MIDI learn

### DIFF
--- a/test_midi_learn.js
+++ b/test_midi_learn.js
@@ -13,9 +13,12 @@ handleMIDIMessage({ data: [0xb0, 10, 64] });
 // Define BPM base y rango
 setBaseBpm(120);
 setTempoRangeBPM(20);
-// Incrementa dentro del rango (120 + 10)
-handleMIDIMessage({ data: [0xb0, 10, 127] });
-assert.ok(Math.abs(getTempoMultiplier() - 130 / 120) < 1e-6);
+// Disminuye dentro del rango (120 - 10)
+handleMIDIMessage({ data: [0xb0, 10, 0] });
+assert.ok(Math.abs(getTempoMultiplier() - 110 / 120) < 1e-6);
+// Cambia el BPM base y verifica que el offset persista (-10)
+setBaseBpm(150);
+assert.ok(Math.abs(getTempoMultiplier() - 140 / 150) < 1e-6);
 // Intenta disminuir por debajo del mínimo permitido (no menos de 10% debajo del base)
 setTempoRangeBPM(40);
 handleMIDIMessage({ data: [0xb0, 10, 0] });


### PR DESCRIPTION
## Summary
- Keep tempo adjustments from MIDI learn by tracking BPM offset and reapplying on tempo changes
- Preserve tempo offset when restarting or stopping playback
- Extend MIDI learn test to verify offset persistence across base BPM changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae9e9d02208333821d9577d9852027