### PR TITLE
Remove tempo sensitivity control for MIDI learn

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,17 +65,6 @@
       title="MIDI Learn"
       data-help="Asigna un control MIDI para ajustar la velocidad de reproducción de la animación."
     >MIDI Learn</button>
-    <label id="tempo-sensitivity-label" title="Sensibilidad de tempo" data-help="Controla cuánto cambia la velocidad con cada tic del control MIDI." >
-      Sensibilidad
-      <input
-        type="range"
-        id="tempo-sensitivity"
-        min="0.001"
-        max="0.1"
-        step="0.001"
-        value="0.01"
-      />
-    </label>
     <label
       id="tempo-range-label"
       title="Rango de tempo"

--- a/script.js
+++ b/script.js
@@ -114,7 +114,6 @@ function getSuperSampling() {
 
 // Variables y funciones para control de tempo mediante MIDI
 let tempoMultiplier = 1;
-let tempoSensitivity = 0.01;
 let midiLearnMode = false;
 let midiBinding = null;
 let tempoMinMultiplier = 0.9;
@@ -125,11 +124,6 @@ let tempoOffsetBpm = 0;
 
 function startMidiLearn() {
   midiLearnMode = true;
-}
-
-function setTempoSensitivity(val) {
-  const v = parseFloat(val);
-  if (!isNaN(v)) tempoSensitivity = v;
 }
 
 function getTempoMultiplier() {
@@ -1312,7 +1306,6 @@ if (typeof document !== 'undefined') {
         }
       },
       onMidiLearn: () => startMidiLearn(),
-      onSensitivityChange: (val) => setTempoSensitivity(val),
       onRangeChange: (range) => setTempoRangeBPM(range),
     });
     if (uiControls.toggleFPSBtn) {
@@ -2064,7 +2057,6 @@ if (typeof module !== 'undefined') {
     getShapeExtension,
     getShapeExtensions,
     startMidiLearn,
-    setTempoSensitivity,
     getTempoMultiplier,
     setTempoRangeBPM,
     getTempoRangeBPM,

--- a/ui.js
+++ b/ui.js
@@ -13,7 +13,6 @@ function initializeUI({
   onFullScreen,
   onToggleFPS,
   onMidiLearn,
-  onSensitivityChange,
   onRangeChange,
 }) {
   const playBtn = document.getElementById('play-stop');
@@ -25,7 +24,6 @@ function initializeUI({
   const fullScreenBtn = document.getElementById('full-screen');
   const toggleFPSBtn = document.getElementById('toggle-fps');
   const midiLearnBtn = document.getElementById('midi-learn');
-  const tempoSensitivityInput = document.getElementById('tempo-sensitivity');
   const tempoRangeInput = document.getElementById('tempo-range');
 
   playBtn.addEventListener('click', () => {
@@ -48,11 +46,6 @@ function initializeUI({
   if (midiLearnBtn && onMidiLearn) {
     midiLearnBtn.addEventListener('click', () => onMidiLearn());
   }
-  if (tempoSensitivityInput && onSensitivityChange) {
-    tempoSensitivityInput.addEventListener('input', (e) =>
-      onSensitivityChange(e.target.value)
-    );
-  }
   if (tempoRangeInput && onRangeChange) {
     tempoRangeInput.addEventListener('input', (e) =>
       onRangeChange(parseFloat(e.target.value))
@@ -69,7 +62,6 @@ function initializeUI({
     fullScreenBtn,
     toggleFPSBtn,
     midiLearnBtn,
-    tempoSensitivityInput,
     tempoRangeInput,
   };
 }


### PR DESCRIPTION
## Summary
- remove tempo sensitivity slider and related logic so MIDI tempo only follows BPM range

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aea00047088333b48311ce001ea91b