### PR TITLE
Fix tap tempo availability initialization error

### DIFF
--- a/script.js
+++ b/script.js
@@ -325,10 +325,11 @@ if (typeof document !== 'undefined') {
     let tapTempoMap = null;
     let devMode = null;
     let draggingMarkerId = null;
+    const audioPlayer = createAudioPlayer();
 
     function updateTapTempoAvailability() {
       if (!startTapTempoBtn) return;
-      const hasAudio = !!audioPlayer.getAudioBuffer();
+      const hasAudio = !!(audioPlayer && audioPlayer.getAudioBuffer());
       startTapTempoBtn.disabled = !hasAudio || tapTempoActive;
       if (!hasAudio && tapTempoStatus) {
         tapTempoStatus.textContent =
@@ -1223,7 +1224,6 @@ if (typeof document !== 'undefined') {
     let tempoMap = [];
     let originalTempoMap = [];
     let timeDivision = 1;
-    const audioPlayer = createAudioPlayer();
 
     function saveAssignments() {
       if (typeof localStorage !== 'undefined') {


### PR DESCRIPTION
## Summary
- initialize the audio player before tap-tempo helpers use it
- keep the tap-tempo button disabled when the audio buffer is missing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f2e248f6008333abd228bf75e6e6f0