### PR TITLE
Fix navigation buttons to update animation seek

### DIFF
--- a/script.js
+++ b/script.js
@@ -1215,6 +1215,7 @@ if (typeof document !== 'undefined') {
     let startIndex = 0;
     let endIndex = 0;
     let lastTime = 0;
+    const BACKWARD_TOLERANCE = 1 / 120;
     const NOTE_MIN = 21;
     const NOTE_MAX = 108;
     const BASE_HEIGHT = 720;
@@ -1841,15 +1842,22 @@ if (typeof document !== 'undefined') {
     }
 
     function renderFrame(currentSec) {
+      if (typeof currentSec !== 'number' || !isFinite(currentSec)) {
+        currentSec = lastTime;
+      }
+      const movedBackward = currentSec + BACKWARD_TOLERANCE < lastTime;
+      if (movedBackward) {
+        startIndex = 0;
+        endIndex = 0;
+      } else if (currentSec < lastTime) {
+        currentSec = lastTime;
+      }
+      lastTime = currentSec;
       offscreenCtx.clearRect(0, 0, canvas.width, canvas.height);
       // Usa el color de fondo asignado al canvas para rellenar cada frame
       offscreenCtx.fillStyle = canvas.style.backgroundColor || '#000000';
       offscreenCtx.fillRect(0, 0, canvas.width, canvas.height);
       const noteHeight = canvas.height / 88;
-      if (currentSec < lastTime) {
-        currentSec = lastTime;
-      }
-      lastTime = currentSec;
       const windowStart = currentSec - visibleSeconds / 2;
       const windowEnd = currentSec + visibleSeconds / 2;
       while (startIndex < notes.length && notes[startIndex].end < windowStart)


### PR DESCRIPTION
## Summary
- allow renderFrame to detect backward seeks and reset cached note indices so the animation reflects manual navigation
- guard against invalid timestamps and add a tolerance to keep the timeline monotonic during normal playback

## Testing
- node test_playback_controls.js
- node test_restart_button.js
- node test_offscreen_render.js
- node test_animation_controls.js
- node test_ui_integration.js

------
https://chatgpt.com/codex/tasks/task_e_68f2e41f186483339b1eee482fba8649