### PR TITLE
Fix tap tempo initialization and add favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Visualizador MIDI - Jaime Jaramillo Arias</title>
   <link rel="stylesheet" href="styles.css" />
+  <link
+    rel="icon"
+    type="image/svg+xml"
+    href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' ry='12' fill='%23000'/%3E%3Ctext x='32' y='42' font-family='Arial' font-size='32' text-anchor='middle' fill='%23fff'%3EM%3C/text%3E%3C/svg%3E"
+  />
 </head>
 <body>
   <h1 id="app-title">Visualizador MIDI - Jaime Jaramillo Arias</h1>

--- a/script.js
+++ b/script.js
@@ -299,6 +299,7 @@ if (typeof document !== 'undefined') {
     let waveformView = { start: 0, duration: 0 };
     let tapTempoStartReference = 0;
     let tapTempoMap = null;
+    let originalTempoMap = [];
     let devMode = null;
     let draggingMarkerId = null;
     let markerHandles = [];
@@ -1501,7 +1502,6 @@ if (typeof document !== 'undefined') {
     pixelsPerSecond = canvas.width / visibleSeconds;
     let stopLoop = null;
     let tempoMap = [];
-    let originalTempoMap = [];
     let timeDivision = 1;
 
     function saveAssignments() {


### PR DESCRIPTION
## Summary
- initialize the original tempo map before checking tap tempo availability to avoid runtime errors
- add an inline SVG favicon so browsers no longer request a missing resource

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f2f1be02348333b94777fcf6049a32