### PR TITLE
Add melody guide lines and normalize audio playback

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -96,7 +96,7 @@ input:hover {
   width: calc(100% - 20px);
   justify-content: center;
   font-size: inherit;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 #family-config-panel.active {
@@ -149,6 +149,55 @@ input:hover {
 
 .family-config-item label {
   min-width: 150px;
+}
+
+.family-line-item {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.family-line-item label,
+.family-line-item span {
+  min-width: 0;
+}
+
+.family-line-title {
+  font-weight: 600;
+}
+
+.family-line-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.family-line-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: space-between;
+}
+
+.family-line-row span {
+  flex: 0 0 auto;
+}
+
+.family-line-range {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+}
+
+.family-line-range input[type='range'] {
+  flex: 1;
+}
+
+.family-line-range .range-value {
+  min-width: 3ch;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 
 #visualizer {

--- a/test_config_export_import.js
+++ b/test_config_export_import.js
@@ -36,6 +36,8 @@ const config = {
   visibleSeconds: 6,
   heightScale: { global: 1, families: {} },
   shapeExtensions: { oval: true, capsule: true, star: true, diamond: true },
+  familyLineSettings: {},
+  familyTravelSettings: {},
 };
 
 importConfiguration(config, tracks, notes);

--- a/utils.js
+++ b/utils.js
@@ -419,6 +419,132 @@ function getShapeExtensions() {
 
 loadShapeExtensions();
 
+const DEFAULT_LINE_SETTINGS = { enabled: true, opacity: 0.45, width: 1.5 };
+let familyLineSettings = {};
+let familyTravelSettings = {};
+
+function sanitizeLineSettings(config = {}) {
+  const sanitized = { ...DEFAULT_LINE_SETTINGS };
+  if (typeof config.enabled === 'boolean') sanitized.enabled = config.enabled;
+  if (typeof config.opacity === 'number' && isFinite(config.opacity)) {
+    sanitized.opacity = Math.min(Math.max(config.opacity, 0), 1);
+  }
+  if (typeof config.width === 'number' && isFinite(config.width)) {
+    sanitized.width = Math.max(config.width, 0.25);
+  }
+  return sanitized;
+}
+
+function loadFamilyLineSettings() {
+  if (typeof localStorage === 'undefined') return;
+  const stored = localStorage.getItem('familyLineSettings');
+  if (!stored) return;
+  try {
+    const parsed = JSON.parse(stored);
+    if (parsed && typeof parsed === 'object') {
+      familyLineSettings = Object.entries(parsed).reduce((acc, [family, cfg]) => {
+        acc[family] = sanitizeLineSettings(cfg);
+        return acc;
+      }, {});
+    }
+  } catch {
+    familyLineSettings = {};
+  }
+}
+
+function persistFamilyLineSettings() {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem('familyLineSettings', JSON.stringify(familyLineSettings));
+}
+
+function getFamilyLineSettings(family) {
+  if (!Object.keys(familyLineSettings).length) loadFamilyLineSettings();
+  const stored = familyLineSettings[family];
+  return stored ? { ...stored } : { ...DEFAULT_LINE_SETTINGS };
+}
+
+function updateFamilyLineSettings(family, updates = {}) {
+  const current = getFamilyLineSettings(family);
+  const merged = sanitizeLineSettings({ ...current, ...updates });
+  familyLineSettings[family] = merged;
+  persistFamilyLineSettings();
+  return merged;
+}
+
+function getAllFamilyLineSettings() {
+  if (!Object.keys(familyLineSettings).length) loadFamilyLineSettings();
+  return { ...familyLineSettings };
+}
+
+function setAllFamilyLineSettings(settings = {}) {
+  familyLineSettings = Object.entries(settings || {}).reduce(
+    (acc, [family, cfg]) => {
+      acc[family] = sanitizeLineSettings(cfg);
+      return acc;
+    },
+    {},
+  );
+  persistFamilyLineSettings();
+}
+
+function resetFamilyLineSettings() {
+  familyLineSettings = {};
+  persistFamilyLineSettings();
+}
+
+function loadFamilyTravelSettings() {
+  if (typeof localStorage === 'undefined') return;
+  const stored = localStorage.getItem('familyTravelSettings');
+  if (!stored) return;
+  try {
+    const parsed = JSON.parse(stored);
+    if (parsed && typeof parsed === 'object') {
+      familyTravelSettings = Object.entries(parsed).reduce((acc, [family, enabled]) => {
+        acc[family] = !!enabled;
+        return acc;
+      }, {});
+    }
+  } catch {
+    familyTravelSettings = {};
+  }
+}
+
+function persistFamilyTravelSettings() {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem('familyTravelSettings', JSON.stringify(familyTravelSettings));
+}
+
+function isTravelEffectEnabled(family) {
+  if (!Object.keys(familyTravelSettings).length) loadFamilyTravelSettings();
+  return !!familyTravelSettings[family];
+}
+
+function setTravelEffectEnabled(family, enabled) {
+  familyTravelSettings[family] = !!enabled;
+  persistFamilyTravelSettings();
+}
+
+function getTravelEffectSettings() {
+  if (!Object.keys(familyTravelSettings).length) loadFamilyTravelSettings();
+  return { ...familyTravelSettings };
+}
+
+function setTravelEffectSettings(settings = {}) {
+  familyTravelSettings = Object.entries(settings || {}).reduce(
+    (acc, [family, enabled]) => {
+      acc[family] = !!enabled;
+      return acc;
+    },
+    {},
+  );
+  persistFamilyTravelSettings();
+}
+
+function resetTravelEffectSettings() {
+  familyTravelSettings = {};
+  persistFamilyTravelSettings();
+}
+
 function getFamilyModifiers(family) {
   switch (family) {
     case 'Platillos':
@@ -647,6 +773,16 @@ const utils = {
   setShapeExtension,
   getShapeExtension,
   getShapeExtensions,
+  getFamilyLineSettings,
+  updateFamilyLineSettings,
+  getAllFamilyLineSettings,
+  setAllFamilyLineSettings,
+  resetFamilyLineSettings,
+  isTravelEffectEnabled,
+  setTravelEffectEnabled,
+  getTravelEffectSettings,
+  setTravelEffectSettings,
+  resetTravelEffectSettings,
   NON_STRETCHED_SHAPES,
   SHAPE_OPTIONS,
   getFamilyModifiers,

--- a/wavLoader.js
+++ b/wavLoader.js
@@ -15,16 +15,48 @@
     return 0;
   }
 
+  function normalizeAudioBuffer(audioBuffer, targetDb = -0.1) {
+    if (!audioBuffer) return audioBuffer;
+    const targetAmplitude = Math.pow(10, targetDb / 20);
+    if (!isFinite(targetAmplitude) || targetAmplitude <= 0) {
+      return audioBuffer;
+    }
+
+    let peak = 0;
+    for (let channelIndex = 0; channelIndex < audioBuffer.numberOfChannels; channelIndex++) {
+      const data = audioBuffer.getChannelData(channelIndex);
+      for (let i = 0; i < data.length; i++) {
+        const absSample = Math.abs(data[i]);
+        if (absSample > peak) peak = absSample;
+      }
+    }
+
+    if (peak === 0) return audioBuffer;
+
+    const gain = targetAmplitude / peak;
+    if (!isFinite(gain) || gain === 1) return audioBuffer;
+
+    for (let channelIndex = 0; channelIndex < audioBuffer.numberOfChannels; channelIndex++) {
+      const data = audioBuffer.getChannelData(channelIndex);
+      for (let i = 0; i < data.length; i++) {
+        data[i] *= gain;
+      }
+    }
+
+    return audioBuffer;
+  }
+
   async function loadWavFile(file, audioCtx) {
     if (!file) throw new Error('No se proporcionó archivo');
     const arrayBuffer = await file.arrayBuffer();
     const audioBuffer = await audioCtx.decodeAudioData(arrayBuffer);
+    normalizeAudioBuffer(audioBuffer, -0.1);
     const channel = audioBuffer.getChannelData(0);
     const trimOffset = detectTrimOffset(channel, audioBuffer.sampleRate);
     return { audioBuffer, trimOffset };
   }
 
-  const api = { loadWavFile, detectTrimOffset };
+  const api = { loadWavFile, detectTrimOffset, normalizeAudioBuffer };
   if (typeof module !== 'undefined') module.exports = api;
   else global.wavLoader = api;
 })(typeof window !== 'undefined' ? window : global);


### PR DESCRIPTION
## Summary
- normalize imported WAV buffers to -0.1 dB peak before playback
- expose per-family controls for melody guide lines with adjustable opacity, width, and travel animations
- render curved track connection lines and post-note travel effects tied to the new configuration options

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f2f37aa42483338e5ccd194dad8d14