### PR TITLE
Restructure family customization controls

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -151,6 +151,35 @@ input:hover {
   min-width: 150px;
 }
 
+.family-config-group {
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.family-config-group label {
+  flex: 1 1 160px;
+}
+
+.family-config-group select,
+.family-config-group input[type='color'] {
+  flex: 1 1 160px;
+}
+
+.family-config-group .control-hint {
+  flex: 1 1 100%;
+  text-align: right;
+}
+
+.control-hint {
+  font-size: 0.85em;
+  opacity: 0.7;
+}
+
+.control-hint.hint-active {
+  font-style: italic;
+}
+
 .family-line-item {
   flex-direction: column;
   align-items: stretch;
@@ -177,6 +206,15 @@ input:hover {
   align-items: center;
   gap: 8px;
   justify-content: space-between;
+}
+
+.family-line-header span {
+  flex: 1 1 auto;
+}
+
+.family-line-header select {
+  flex: 1 1 60%;
+  max-width: 60%;
 }
 
 .family-line-row span {


### PR DESCRIPTION
## Summary
- reorganized the developer panel to manage family colors, shapes, and line/travel settings through dropdown selectors with global or per-family scope
- added aggregated state handling so shared controls reflect mixed values and update all affected families while refreshing the preview
- updated styles to support the new grouped layout and status hints for the simplified controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f2f8e787c0833385a180596b3a75ae