### PR TITLE
Simplify family configuration targeting and adjust note travel timing

### DIFF
--- a/script.js
+++ b/script.js
@@ -1697,6 +1697,7 @@ if (typeof document !== 'undefined') {
       instTitle.textContent = 'Instrumentos activos';
       instSection.appendChild(instTitle);
       const instBtnWrap = document.createElement('div');
+      instBtnWrap.className = 'inst-button-row';
       const activateAllBtn = document.createElement('button');
       activateAllBtn.textContent = 'Activar todos';
       activateAllBtn.addEventListener('click', () => {
@@ -1722,7 +1723,7 @@ if (typeof document !== 'undefined') {
       instSection.appendChild(instBtnWrap);
       currentTracks.forEach((t) => {
         const item = document.createElement('div');
-        item.className = 'family-config-item';
+        item.className = 'family-config-item family-checkbox-item';
         const checkbox = document.createElement('input');
         checkbox.type = 'checkbox';
         checkbox.checked = enabledInstruments[t.name] !== false;
@@ -1760,27 +1761,38 @@ if (typeof document !== 'undefined') {
         }
       });
 
+      const targetControl = document.createElement('div');
+      targetControl.className = 'family-config-item family-target-control';
+      const targetLabel = document.createElement('label');
+      targetLabel.textContent = 'Aplicar cambios a:';
+      targetLabel.setAttribute('for', 'family-target-select');
+      const familyTargetSelect = createFamilySelector();
+      familyTargetSelect.id = 'family-target-select';
+      targetControl.appendChild(targetLabel);
+      targetControl.appendChild(familyTargetSelect);
+      targetControl.dataset.help =
+        'Elige si los ajustes afectan a todas las familias o solo a una.';
+      familyPanel.appendChild(targetControl);
+
       const colorControl = document.createElement('div');
       colorControl.className = 'family-config-item family-config-group';
       const colorLabel = document.createElement('label');
       colorLabel.textContent = 'Color de familia:';
-      const colorFamilySelect = createFamilySelector();
       const colorInput = document.createElement('input');
       colorInput.type = 'color';
       const colorHint = document.createElement('span');
       colorHint.className = 'control-hint';
 
       const updateColorControl = () => {
-        const { color, mixed } = getColorState(colorFamilySelect.value);
+        const { color, mixed } = getColorState(familyTargetSelect.value);
         colorInput.value = color;
         colorHint.textContent = mixed ? 'Valores variados' : color.toUpperCase();
         colorHint.classList.toggle('hint-active', mixed);
       };
 
-      colorFamilySelect.addEventListener('change', updateColorControl);
       colorInput.addEventListener('change', () => {
         const color = colorInput.value;
-        familiesFromSelection(colorFamilySelect.value).forEach((family) =>
+        familiesFromSelection(familyTargetSelect.value).forEach((family) =>
           setFamilyCustomization(
             family,
             { color },
@@ -1793,7 +1805,6 @@ if (typeof document !== 'undefined') {
       });
 
       colorControl.appendChild(colorLabel);
-      colorControl.appendChild(colorFamilySelect);
       colorControl.appendChild(colorInput);
       colorControl.appendChild(colorHint);
       familyPanel.appendChild(colorControl);
@@ -1802,7 +1813,6 @@ if (typeof document !== 'undefined') {
       shapeControl.className = 'family-config-item family-config-group';
       const shapeLabel = document.createElement('label');
       shapeLabel.textContent = 'Figura de familia:';
-      const shapeFamilySelect = createFamilySelector();
       const shapeSelect = document.createElement('select');
       SHAPE_OPTIONS.forEach((opt) => {
         const option = document.createElement('option');
@@ -1814,7 +1824,7 @@ if (typeof document !== 'undefined') {
       shapeHint.className = 'control-hint';
 
       const updateShapeControl = () => {
-        const { shape, mixed } = getShapeState(shapeFamilySelect.value);
+        const { shape, mixed } = getShapeState(familyTargetSelect.value);
         if (shapeSelect.querySelector(`option[value="${shape}"]`)) {
           shapeSelect.value = shape;
         } else if (SHAPE_OPTIONS[0]) {
@@ -1829,10 +1839,9 @@ if (typeof document !== 'undefined') {
         shapeHint.classList.toggle('hint-active', mixed);
       };
 
-      shapeFamilySelect.addEventListener('change', updateShapeControl);
       shapeSelect.addEventListener('change', () => {
         const shape = shapeSelect.value;
-        familiesFromSelection(shapeFamilySelect.value).forEach((family) =>
+        familiesFromSelection(familyTargetSelect.value).forEach((family) =>
           setFamilyCustomization(
             family,
             { shape },
@@ -1845,7 +1854,6 @@ if (typeof document !== 'undefined') {
       });
 
       shapeControl.appendChild(shapeLabel);
-      shapeControl.appendChild(shapeFamilySelect);
       shapeControl.appendChild(shapeSelect);
       shapeControl.appendChild(shapeHint);
       familyPanel.appendChild(shapeControl);
@@ -1853,12 +1861,11 @@ if (typeof document !== 'undefined') {
       const lineControl = document.createElement('div');
       lineControl.className = 'family-config-item family-line-item';
       const lineHeader = document.createElement('div');
-      lineHeader.className = 'family-line-row family-line-header';
-      const lineFamilyLabel = document.createElement('span');
-      lineFamilyLabel.textContent = 'Familia línea:';
-      const lineFamilySelect = createFamilySelector();
-      lineHeader.appendChild(lineFamilyLabel);
-      lineHeader.appendChild(lineFamilySelect);
+      lineHeader.className = 'family-line-header';
+      const lineHeaderTitle = document.createElement('span');
+      lineHeaderTitle.className = 'family-line-title';
+      lineHeaderTitle.textContent = 'Líneas de conexión';
+      lineHeader.appendChild(lineHeaderTitle);
       lineControl.appendChild(lineHeader);
 
       const lineToggleLabel = document.createElement('label');
@@ -1913,12 +1920,12 @@ if (typeof document !== 'undefined') {
       travelToggle.type = 'checkbox';
       travelToggleLabel.appendChild(travelToggle);
       travelToggleLabel.appendChild(
-        document.createTextNode(' Viaje tras NOTE OFF'),
+        document.createTextNode(' Viaje desde NOTE ON'),
       );
       lineControl.appendChild(travelToggleLabel);
 
       const updateLineControl = () => {
-        const state = getLineState(lineFamilySelect.value);
+        const state = getLineState(familyTargetSelect.value);
         lineToggle.checked = state.enabled;
         lineToggle.indeterminate = state.mixedEnabled;
         lineOpacity.value = String(state.opacity);
@@ -1935,11 +1942,10 @@ if (typeof document !== 'undefined') {
         travelToggle.indeterminate = state.mixedTravel;
       };
 
-      lineFamilySelect.addEventListener('change', updateLineControl);
       lineToggle.addEventListener('change', () => {
         const enabled = lineToggle.checked;
         lineToggle.indeterminate = false;
-        familiesFromSelection(lineFamilySelect.value).forEach((family) =>
+        familiesFromSelection(familyTargetSelect.value).forEach((family) =>
           updateFamilyLineSettings(family, { enabled }),
         );
         renderFrame(lastTime);
@@ -1947,7 +1953,7 @@ if (typeof document !== 'undefined') {
       });
       lineOpacity.addEventListener('input', () => {
         const value = parseFloat(lineOpacity.value);
-        familiesFromSelection(lineFamilySelect.value).forEach((family) =>
+        familiesFromSelection(familyTargetSelect.value).forEach((family) =>
           updateFamilyLineSettings(family, { opacity: value }),
         );
         renderFrame(lastTime);
@@ -1955,7 +1961,7 @@ if (typeof document !== 'undefined') {
       });
       lineWidth.addEventListener('input', () => {
         const value = parseFloat(lineWidth.value);
-        familiesFromSelection(lineFamilySelect.value).forEach((family) =>
+        familiesFromSelection(familyTargetSelect.value).forEach((family) =>
           updateFamilyLineSettings(family, { width: value }),
         );
         renderFrame(lastTime);
@@ -1964,7 +1970,7 @@ if (typeof document !== 'undefined') {
       travelToggle.addEventListener('change', () => {
         const enabled = travelToggle.checked;
         travelToggle.indeterminate = false;
-        familiesFromSelection(lineFamilySelect.value).forEach((family) =>
+        familiesFromSelection(familyTargetSelect.value).forEach((family) =>
           setTravelEffectEnabled(family, enabled),
         );
         renderFrame(lastTime);
@@ -1972,6 +1978,12 @@ if (typeof document !== 'undefined') {
       });
 
       familyPanel.appendChild(lineControl);
+
+      familyTargetSelect.addEventListener('change', () => {
+        updateColorControl();
+        updateShapeControl();
+        updateLineControl();
+      });
 
       updateColorControl();
       updateShapeControl();
@@ -2491,10 +2503,10 @@ if (typeof document !== 'undefined') {
         }
 
         const travelEnabled = isTravelEffectEnabled(note.family);
-        if (travelEnabled && note.next && note.next.start > note.end) {
-          const travelDuration = note.next.start - note.end;
+        if (travelEnabled && note.next && note.next.start > note.start) {
+          const travelDuration = note.next.start - note.start;
           if (travelDuration > 0) {
-            const travelProgress = (currentSec - note.end) / travelDuration;
+            const travelProgress = (currentSec - note.start) / travelDuration;
             if (travelProgress >= 0) {
               layout.drawBase = currentSec < note.end;
               if (travelProgress <= 1) {
@@ -2580,12 +2592,12 @@ if (typeof document !== 'undefined') {
       }
 
       activeTravels.forEach(({ note, progress, layout }) => {
-        const duration = note.next.start - note.end;
+        const duration = note.next.start - note.start;
         if (duration <= 0) return;
         const clamped = Math.min(Math.max(progress, 0), 1);
-        const startLayout = computeLayoutAt(note, note.end);
+        const startLayout = computeLayoutAt(note, note.start);
         const targetLayout = computeLayoutAt(note.next, note.next.start);
-        const startShift = (currentSec - note.end) * pixelsPerSecond;
+        const startShift = (currentSec - note.start) * pixelsPerSecond;
         const targetShift = (currentSec - note.next.start) * pixelsPerSecond;
         const startX = startLayout.centerX - startShift;
         const startY = startLayout.centerY;

--- a/styles.css
+++ b/styles.css
@@ -89,14 +89,14 @@ input:hover {
 
 #family-config-panel {
   display: none;
-  gap: 10px;
   margin: 0 10px 10px;
   background: #222;
-  padding: 10px;
+  padding: 16px;
   width: calc(100% - 20px);
-  justify-content: center;
+  box-sizing: border-box;
   font-size: inherit;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
 }
 
 #family-config-panel.active {
@@ -104,76 +104,105 @@ input:hover {
 }
 
 #developer-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
   width: 100%;
-  margin-bottom: 10px;
-  justify-content: center;
+  margin-bottom: 16px;
+  padding: 12px;
+  background: #1c1c1c;
+  border-radius: 8px;
+  box-sizing: border-box;
   font-size: inherit;
   grid-column: 1 / -1;
 }
 
-.side-column {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+.dev-control {
+  display: grid;
+  gap: 8px;
+  align-items: start;
+  background: #2a2a2a;
+  padding: 12px;
+  border-radius: 6px;
+}
+
+.dev-control label {
+  min-width: 0;
+  font-weight: 600;
+}
+
+.dev-control input,
+.dev-control select {
+  width: 100%;
 }
 
 .inst-section {
   grid-column: 1 / -1;
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
+  display: grid;
+  gap: 10px;
+  background: #2a2a2a;
+  padding: 12px;
+  border-radius: 6px;
 }
 
-.dev-control {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  background: #333;
-  padding: 5px;
+.inst-section h4 {
+  margin: 0;
+  font-size: 1rem;
 }
 
-.dev-control label {
-  min-width: 120px;
+.inst-button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.inst-button-row button {
+  flex: 1 1 140px;
 }
 
 .family-config-item {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  background: #333;
-  padding: 5px;
+  display: grid;
+  gap: 8px;
+  align-items: start;
+  background: #2a2a2a;
+  padding: 12px;
+  border-radius: 6px;
 }
 
 .family-config-item label {
-  min-width: 150px;
+  min-width: 0;
+  font-weight: 600;
+}
+
+.family-checkbox-item {
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  background: transparent;
+  padding: 0;
+  gap: 10px;
+}
+
+.family-checkbox-item label {
+  font-weight: 500;
 }
 
 .family-config-group {
-  flex-wrap: wrap;
-  align-items: center;
   gap: 8px;
-}
-
-.family-config-group label {
-  flex: 1 1 160px;
 }
 
 .family-config-group select,
 .family-config-group input[type='color'] {
-  flex: 1 1 160px;
+  width: 100%;
 }
 
-.family-config-group .control-hint {
-  flex: 1 1 100%;
-  text-align: right;
+.family-target-control {
+  gap: 8px;
 }
 
 .control-hint {
   font-size: 0.85em;
   opacity: 0.7;
+  text-align: right;
 }
 
 .control-hint.hint-active {
@@ -181,40 +210,30 @@ input:hover {
 }
 
 .family-line-item {
-  flex-direction: column;
-  align-items: stretch;
-  gap: 8px;
-}
-
-.family-line-item label,
-.family-line-item span {
-  min-width: 0;
+  gap: 12px;
 }
 
 .family-line-title {
   font-weight: 600;
 }
 
+.family-line-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .family-line-toggle {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
 }
 
 .family-line-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
   justify-content: space-between;
-}
-
-.family-line-header span {
-  flex: 1 1 auto;
-}
-
-.family-line-header select {
-  flex: 1 1 60%;
-  max-width: 60%;
 }
 
 .family-line-row span {


### PR DESCRIPTION
## Summary
- add a shared family target selector so color, shape, and line controls respond to the same scope and improve instrument toggles
- reorganize developer mode styling into a balanced grid layout for clearer cards and tool groups
- start the note travel animation option at NOTE ON events and update its label to match

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f2fd46ee4c8333912db1d4aab85285