### PR TITLE
Simplify bottom controls for family parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,38 +103,85 @@
   />
 
   <nav id="bottom-menu">
-    <select
-      id="instrument-select"
-      title="Seleccionar instrumento"
-      data-help="Lista de instrumentos disponibles en el archivo MIDI."
-    >
-      <option>Instrumento</option>
-    </select>
-    <select
-      id="family-select"
-      title="Seleccionar familia"
-      data-help="Permite asignar una familia al instrumento seleccionado."
-    >
-      <option value="">Familia</option>
-      <option>Maderas de timbre "redondo"</option>
-      <option>Dobles cañas</option>
-      <option>Saxofones</option>
-      <option>Metales</option>
-      <option>Cornos</option>
-      <option>Percusión menor</option>
-      <option>Tambores</option>
-      <option>Platillos</option>
-      <option>Placas</option>
-      <option>Auxiliares</option>
-      <option>Cuerdas frotadas</option>
-      <option>Cuerdas pulsadas</option>
-      <option>Voces</option>
-      <option>Custom 1</option>
-      <option>Custom 2</option>
-      <option>Custom 3</option>
-      <option>Custom 4</option>
-      <option>Custom 5</option>
-    </select>
+    <div class="family-parameter">
+      <label for="family-parameter-select">Familia</label>
+      <select
+        id="family-parameter-select"
+        title="Seleccionar familia para ajustar parámetros"
+        data-help="Elige una familia o la opción general para ajustar sus parámetros de animación."
+      >
+        <option value="">General</option>
+        <option>Maderas de timbre "redondo"</option>
+        <option>Dobles cañas</option>
+        <option>Saxofones</option>
+        <option>Metales</option>
+        <option>Cornos</option>
+        <option>Percusión menor</option>
+        <option>Tambores</option>
+        <option>Platillos</option>
+        <option>Placas</option>
+        <option>Auxiliares</option>
+        <option>Cuerdas frotadas</option>
+        <option>Cuerdas pulsadas</option>
+        <option>Voces</option>
+        <option>Custom 1</option>
+        <option>Custom 2</option>
+        <option>Custom 3</option>
+        <option>Custom 4</option>
+        <option>Custom 5</option>
+      </select>
+    </div>
+    <div class="family-parameter">
+      <label for="family-height-control">Altura</label>
+      <input
+        type="range"
+        id="family-height-control"
+        min="10"
+        max="300"
+        value="100"
+        data-output="family-height-value"
+        title="Ajustar altura"
+        data-help="Controla el tamaño vertical de las notas para la familia seleccionada."
+      />
+      <span id="family-height-value" class="parameter-value">100%</span>
+    </div>
+    <div class="family-parameter">
+      <label for="family-glow-control">Glow</label>
+      <input
+        type="range"
+        id="family-glow-control"
+        min="0"
+        max="300"
+        value="100"
+        data-output="family-glow-value"
+        title="Ajustar glow"
+        data-help="Define la intensidad del brillo al pasar por la línea del presente."
+      />
+      <span id="family-glow-value" class="parameter-value">100%</span>
+    </div>
+    <div class="family-parameter">
+      <label for="family-bump-control">Bump</label>
+      <input
+        type="range"
+        id="family-bump-control"
+        min="0"
+        max="300"
+        value="100"
+        data-output="family-bump-value"
+        title="Ajustar bump"
+        data-help="Gestiona el impulso de altura cuando la nota cruza el presente."
+      />
+      <span id="family-bump-value" class="parameter-value">100%</span>
+    </div>
+    <div class="family-parameter family-parameter-toggle">
+      <label for="family-extension-toggle">Extensión dinámica</label>
+      <input
+        type="checkbox"
+        id="family-extension-toggle"
+        title="Alternar extensión"
+        data-help="Activa o desactiva la extensión progresiva de figuras alargadas para la familia seleccionada."
+      />
+    </div>
     <button
       id="toggle-family-panel"
       title="Panel de familias"

--- a/styles.css
+++ b/styles.css
@@ -36,25 +36,58 @@ body {
 #bottom-menu {
   justify-content: center;
   align-items: center;
+  flex-wrap: wrap;
 }
 
-#bottom-menu #instrument-select,
-#bottom-menu #family-select,
-#bottom-menu #developer-mode {
-  flex: 1;
+#toggle-family-panel {
+  flex: 0 0 40px;
+  min-width: 40px;
+}
+
+#bottom-menu button {
+  text-align: center;
+}
+
+#developer-mode,
+#tap-tempo-mode {
+  flex: 1 1 160px;
   min-width: 150px;
 }
 
-#bottom-menu #toggle-family-panel {
-  flex: 0 0 40px;
-  text-align: center;
-  padding: 6px;
+.family-parameter {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 150px;
+  flex: 1 1 160px;
 }
 
-#bottom-menu select,
-#bottom-menu button {
+.family-parameter label {
+  font-weight: 600;
+}
+
+.family-parameter input[type='range'] {
   width: 100%;
+}
+
+.family-parameter-toggle {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.family-parameter-toggle label {
+  flex: 1;
+}
+
+.family-parameter-toggle input[type='checkbox'] {
+  width: auto;
+  transform: scale(1.2);
+}
+
+.parameter-value {
   text-align: center;
+  font-weight: 600;
 }
 
 button,

--- a/test_bump_control.js
+++ b/test_bump_control.js
@@ -10,5 +10,8 @@ setBumpControl(2);
 approx(computeBumpHeight(base, 0, 0, 1), 20);
 approx(computeBumpHeight(base, 1, 0, 1), 15);
 approx(computeBumpHeight(base, 2, 0, 1), base);
+setBumpControl(1.5, 'Metales');
+approx(computeBumpHeight(base, 0, 0, 1, 0.5, 'Metales'), 17.5);
+approx(computeBumpHeight(base, 1, 0, 1, 0.5, 'Metales'), 12.5);
 
 console.log('Pruebas de control de bump completadas');

--- a/test_canvas_color.js
+++ b/test_canvas_color.js
@@ -7,8 +7,14 @@ const dom = new JSDOM(`<!DOCTYPE html><html><body>
 <input id="midi-file-input" />
 <button id="load-wav"></button>
 <input id="wav-file-input" />
-<select id="instrument-select"></select>
-<select id="family-select"></select>
+<select id="family-parameter-select"></select>
+<input id="family-height-control" data-output="family-height-value" />
+<span id="family-height-value"></span>
+<input id="family-glow-control" data-output="family-glow-value" />
+<span id="family-glow-value"></span>
+<input id="family-bump-control" data-output="family-bump-value" />
+<span id="family-bump-value"></span>
+<input type="checkbox" id="family-extension-toggle" />
 <button id="toggle-family-panel"></button>
 <button id="developer-mode"></button>
 <div id="family-config-panel"><div id="developer-controls"></div></div>

--- a/test_config_export_import.js
+++ b/test_config_export_import.js
@@ -31,11 +31,12 @@ const config = {
   enabledInstruments: { Flauta: true },
   velocityBase: 80,
   opacityScale: { edge: 0.1, mid: 0.8 },
-  glowStrength: 1.5,
-  bumpControl: 1.2,
+  glowStrength: { global: 1.5, families: { Metales: 1.2 } },
+  bumpControl: { global: 1.2, families: { Metales: 1.1 } },
   visibleSeconds: 6,
   heightScale: { global: 1, families: {} },
   shapeExtensions: { oval: true, capsule: true, star: true, diamond: true },
+  familyExtensions: { Metales: true },
   familyLineSettings: {},
   familyTravelSettings: {},
 };
@@ -52,7 +53,9 @@ assert.strictEqual(notes[0].color, '#123456');
 assert.strictEqual(getVelocityBase(), 80);
 assert.deepStrictEqual(getOpacityScale(), { edge: 0.1, mid: 0.8 });
 assert.strictEqual(getGlowStrength(), 1.5);
+assert.strictEqual(getGlowStrength('Metales'), 1.2);
 assert.strictEqual(getBumpControl(), 1.2);
+assert.strictEqual(getBumpControl('Metales'), 1.1);
 assert.strictEqual(getVisibleSeconds(), 6);
 assert.deepStrictEqual(getHeightScaleConfig(), { global: 1, families: {} });
 

--- a/test_family_dropdown_custom.js
+++ b/test_family_dropdown_custom.js
@@ -4,7 +4,7 @@ const { JSDOM } = require('jsdom');
 
 const html = fs.readFileSync('./index.html', 'utf-8');
 const dom = new JSDOM(html);
-const options = Array.from(dom.window.document.querySelectorAll('#family-select option')).map(o => o.textContent.trim());
+const options = Array.from(dom.window.document.querySelectorAll('#family-parameter-select option')).map(o => o.textContent.trim());
 ['Custom 1', 'Custom 2', 'Custom 3', 'Custom 4', 'Custom 5'].forEach(f => {
   assert(options.includes(f), `La opción ${f} no está en el menú de familias`);
 });

--- a/test_glow_control.js
+++ b/test_glow_control.js
@@ -7,6 +7,8 @@ function approx(a, b, eps = 1e-6) {
 
 setGlowStrength(2);
 approx(computeGlowAlpha(0.2, 0), 0.5);
+setGlowStrength(1.5, 'Metales');
+approx(computeGlowAlpha(0.15, 0, 0.2, 'Metales'), 0.5);
 
 const ctx = {
   shadowBlur: 0,
@@ -22,7 +24,7 @@ const ctx = {
   fill() {},
 };
 
-applyGlowEffect(ctx, 'square', 0, 0, 10, 10, 0.5);
+applyGlowEffect(ctx, 'square', 0, 0, 10, 10, 0.5, 'Metales');
 assert(ctx.shadowBlur > 20, 'blur no escalado');
 assert.strictEqual(ctx.w, 10, 'el ancho no debe cambiar');
 assert(ctx.h > 10, 'la altura debe escalarse');

--- a/test_modal_shift_selection.js
+++ b/test_modal_shift_selection.js
@@ -7,8 +7,14 @@ const dom = new JSDOM(`<!DOCTYPE html><html><body>
 <input id="midi-file-input" />
 <button id="load-wav"></button>
 <input id="wav-file-input" />
-<select id="instrument-select"></select>
-<select id="family-select"></select>
+<select id="family-parameter-select"></select>
+<input id="family-height-control" data-output="family-height-value" />
+<span id="family-height-value"></span>
+<input id="family-glow-control" data-output="family-glow-value" />
+<span id="family-glow-value"></span>
+<input id="family-bump-control" data-output="family-bump-value" />
+<span id="family-bump-value"></span>
+<input type="checkbox" id="family-extension-toggle" />
 <button id="toggle-family-panel"></button>
 <button id="developer-mode"></button>
 <div id="family-config-panel"><div id="developer-controls"></div></div>

--- a/test_multi_drag.js
+++ b/test_multi_drag.js
@@ -60,8 +60,14 @@ const dom = new JSDOM(`<!DOCTYPE html><html><body>
 <input id="midi-file-input" />
 <button id="load-wav"></button>
 <input id="wav-file-input" />
-<select id="instrument-select"></select>
-<select id="family-select"></select>
+<select id="family-parameter-select"></select>
+<input id="family-height-control" data-output="family-height-value" />
+<span id="family-height-value"></span>
+<input id="family-glow-control" data-output="family-glow-value" />
+<span id="family-glow-value"></span>
+<input id="family-bump-control" data-output="family-bump-value" />
+<span id="family-bump-value"></span>
+<input type="checkbox" id="family-extension-toggle" />
 <button id="toggle-family-panel"></button>
 <button id="developer-mode"></button>
 <div id="family-config-panel"><div id="developer-controls"></div></div>

--- a/test_offscreen_render.js
+++ b/test_offscreen_render.js
@@ -7,8 +7,14 @@ const dom = new JSDOM(`<!DOCTYPE html><html><body>
 <input id="midi-file-input" />
 <button id="load-wav"></button>
 <input id="wav-file-input" />
-<select id="instrument-select"></select>
-<select id="family-select"></select>
+<select id="family-parameter-select"></select>
+<input id="family-height-control" data-output="family-height-value" />
+<span id="family-height-value"></span>
+<input id="family-glow-control" data-output="family-glow-value" />
+<span id="family-glow-value"></span>
+<input id="family-bump-control" data-output="family-bump-value" />
+<span id="family-bump-value"></span>
+<input type="checkbox" id="family-extension-toggle" />
 <button id="toggle-family-panel"></button>
 <button id="developer-mode"></button>
 <div id="family-config-panel"><div id="developer-controls"></div></div>

--- a/test_velocity_note_render.js
+++ b/test_velocity_note_render.js
@@ -7,8 +7,14 @@ const dom = new JSDOM(`<!DOCTYPE html><html><body>
 <input id="midi-file-input" />
 <button id="load-wav"></button>
 <input id="wav-file-input" />
-<select id="instrument-select"></select>
-<select id="family-select"></select>
+<select id="family-parameter-select"></select>
+<input id="family-height-control" data-output="family-height-value" />
+<span id="family-height-value"></span>
+<input id="family-glow-control" data-output="family-glow-value" />
+<span id="family-glow-value"></span>
+<input id="family-bump-control" data-output="family-bump-value" />
+<span id="family-bump-value"></span>
+<input type="checkbox" id="family-extension-toggle" />
 <button id="toggle-family-panel"></button>
 <button id="developer-mode"></button>
 <div id="family-config-panel"><div id="developer-controls"></div></div>


### PR DESCRIPTION
## Summary
- replace the instrument/family selectors with a unified family parameter panel in the bottom menu
- allow height, glow, bump, and extension overrides per family and persist them in configuration
- update supporting utilities, default UI wiring, and tests for the new control surface

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f30014e8dc83338ad5e53bd5eb5225