### PR TITLE
Refine opacity controls and developer color palette

### DIFF
--- a/configuracion.js
+++ b/configuracion.js
@@ -261,7 +261,7 @@ window.DEFAULT_CONFIG = {
   "velocityBase": 127,
   "opacityScale": {
     "edge": 0,
-    "mid": 0.48
+    "mid": 0.5
   },
   "glowStrength": 1,
   "bumpControl": 1.2,

--- a/configuracion.json
+++ b/configuracion.json
@@ -261,7 +261,7 @@
   "velocityBase": 127,
   "opacityScale": {
     "edge": 0,
-    "mid": 0.48
+    "mid": 0.5
   },
   "glowStrength": 1,
   "bumpControl": 1.2,

--- a/styles.css
+++ b/styles.css
@@ -188,9 +188,65 @@ input:hover {
 }
 
 .family-config-group select,
-.family-config-group input[type='color'],
 .family-config-group input[type='number'] {
   width: 100%;
+}
+
+.color-palette {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  width: 100%;
+}
+
+.color-swatch {
+  --swatch-color: #ffffff;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 28px;
+  border-radius: 6px;
+  border: 2px solid transparent;
+  background: var(--swatch-color);
+  cursor: pointer;
+  padding: 0;
+  position: relative;
+  transition: transform 0.15s ease, border-color 0.15s ease;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.color-swatch:not(.custom-preview):hover {
+  transform: scale(1.05);
+}
+
+.color-swatch:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+.color-swatch.selected {
+  border-color: #ffffff;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.25);
+}
+
+.color-swatch.selected::after {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  border-radius: 4px;
+  border: 2px solid rgba(0, 0, 0, 0.35);
+}
+
+.color-swatch.custom-preview {
+  display: none;
+  border-style: dashed;
+  border-color: rgba(255, 255, 255, 0.7);
+  cursor: default;
+  pointer-events: none;
+}
+
+.color-swatch.custom-preview.visible {
+  display: block;
 }
 
 .family-target-control {

--- a/test_opacity_scale.js
+++ b/test_opacity_scale.js
@@ -13,4 +13,6 @@ approx(scale.mid, 0.8);
 approx(computeOpacity(-50, 50, 600), 0.1);
 approx(computeOpacity(125, 175, 600), 0.45);
 
+setOpacityScale(0, 0.5);
+
 console.log('Pruebas de escala de opacidad configurables completadas');

--- a/test_visual_effects.js
+++ b/test_visual_effects.js
@@ -4,6 +4,7 @@ const {
   computeBumpHeight,
   computeGlowAlpha,
   applyGlowEffect,
+  setOpacityScale,
   setGlowStrength,
 } = require('./script');
 
@@ -12,9 +13,13 @@ function approx(actual, expected, eps = 1e-6) {
 }
 
 // Pruebas para computeOpacity
-approx(computeOpacity(250, 350, 600), 1); // Nota cruzando el centro
-approx(computeOpacity(-50, 50, 600), 0.05); // Nota lejos del centro
-approx(computeOpacity(125, 175, 600), 0.375); // Nota a mitad de distancia
+approx(computeOpacity(250, 350, 600), 0.5); // Nota cruzando el centro con escala por defecto
+approx(computeOpacity(-50, 50, 600), 0); // Nota lejos del centro
+approx(computeOpacity(125, 175, 600), 0.25); // Nota a mitad de distancia
+setOpacityScale(0, 1);
+approx(computeOpacity(250, 350, 600), 1); // Centro al 100%
+approx(computeOpacity(125, 175, 600), 0.5); // Gradiente progresivo
+setOpacityScale(0, 0.5);
 
 // Pruebas para computeBumpHeight
 const base = 10;

--- a/utils.js
+++ b/utils.js
@@ -85,7 +85,7 @@ function validateColorRange(bright, dark) {
 }
 
 // Parámetros configurables de opacidad
-let opacityScale = { edge: 0.05, mid: 0.7 };
+let opacityScale = { edge: 0, mid: 0.5 };
 
 function setOpacityScale(edge, mid) {
   opacityScale = { edge, mid };
@@ -117,7 +117,6 @@ getOpacityScale();
 // Calcula opacidad según la distancia de la nota a la línea de presente
 function computeOpacity(xStart, xEnd, canvasWidth) {
   const center = canvasWidth / 2;
-  if (xStart <= center && xEnd >= center) return 1;
   const noteCenter = (xStart + xEnd) / 2;
   const dist = Math.abs(noteCenter - center);
   const maxDist = canvasWidth / 2;
@@ -173,6 +172,7 @@ function setBumpControl(value, family) {
     familyBumpControl[family] = value;
   } else {
     bumpControl = value;
+    familyBumpControl = {};
   }
   persistBumpControl();
 }
@@ -254,6 +254,7 @@ function setHeightScale(value, family) {
     familyHeightScale[family] = value;
   } else {
     heightScale = value;
+    familyHeightScale = {};
   }
   persistHeightScale();
 }
@@ -333,6 +334,7 @@ function setGlowStrength(value, family) {
     familyGlowStrength[family] = value;
   } else {
     glowStrength = value;
+    familyGlowStrength = {};
   }
   persistGlowStrength();
 }
@@ -571,6 +573,12 @@ function clearFamilyExtension(family) {
   setFamilyExtension(family, null);
 }
 
+function clearAllFamilyExtensions() {
+  loadShapeExtensions();
+  familyShapeExtensions = {};
+  persistFamilyShapeExtensions();
+}
+
 function getFamilyExtension(family) {
   loadShapeExtensions();
   if (!family) return null;
@@ -595,9 +603,10 @@ function isExtensionEnabledForFamily(shape, family) {
 
 loadShapeExtensions();
 
-const DEFAULT_LINE_SETTINGS = { enabled: true, opacity: 0.45, width: 1.5 };
+const DEFAULT_LINE_SETTINGS = { enabled: false, opacity: 0.45, width: 1.5 };
 let familyLineSettings = {};
 let familyTravelSettings = {};
+const DEFAULT_TRAVEL_EFFECT = true;
 
 function sanitizeLineSettings(config = {}) {
   const sanitized = { ...DEFAULT_LINE_SETTINGS };
@@ -692,10 +701,14 @@ function persistFamilyTravelSettings() {
 
 function isTravelEffectEnabled(family) {
   if (!Object.keys(familyTravelSettings).length) loadFamilyTravelSettings();
-  return !!familyTravelSettings[family];
+  if (family && Object.prototype.hasOwnProperty.call(familyTravelSettings, family)) {
+    return !!familyTravelSettings[family];
+  }
+  return DEFAULT_TRAVEL_EFFECT;
 }
 
 function setTravelEffectEnabled(family, enabled) {
+  if (!family) return;
   familyTravelSettings[family] = !!enabled;
   persistFamilyTravelSettings();
 }
@@ -960,6 +973,7 @@ const utils = {
   getFamilyExtension,
   getFamilyExtensionConfig,
   clearFamilyExtension,
+  clearAllFamilyExtensions,
   isExtensionEnabledForFamily,
   getFamilyLineSettings,
   updateFamilyLineSettings,


### PR DESCRIPTION
## Summary
- default the renderer to higher supersampling and a 0%/50% opacity scale while keeping gradients smooth
- reset per-family overrides when applying global height/glow/bump changes and simplify dynamic extension management
- replace the developer color input with a swatch palette and disable connection lines globally while keeping travel active

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f51ee5b3748333ac6f0090adc53ebd