### PR TITLE
Improve note outlines and retire unsupported shapes

### DIFF
--- a/configuracion.js
+++ b/configuracion.js
@@ -90,7 +90,7 @@ window.DEFAULT_CONFIG = {
     },
     "Cuerdas pulsadas": {
       "color": "#1abeb4",
-      "shape": "star4"
+      "shape": "circle"
     },
     "Voces": {
       "color": "#bebebe",
@@ -102,7 +102,7 @@ window.DEFAULT_CONFIG = {
     },
     "Percusión menor": {
       "color": "#a78269",
-      "shape": "pentagon"
+      "shape": "square"
     }
   },
   "enabledInstruments": {

--- a/configuracion.json
+++ b/configuracion.json
@@ -90,7 +90,7 @@
     },
     "Cuerdas pulsadas": {
       "color": "#1abeb4",
-      "shape": "star4"
+      "shape": "circle"
     },
     "Voces": {
       "color": "#bebebe",
@@ -102,7 +102,7 @@
     },
     "Percusión menor": {
       "color": "#a78269",
-      "shape": "pentagon"
+      "shape": "square"
     }
   },
   "enabledInstruments": {

--- a/script.js
+++ b/script.js
@@ -7,6 +7,7 @@ const {
   computeBumpHeight,
   computeGlowAlpha,
   drawNoteShape,
+  computeNoteStrokeWidth,
   interpolateColor,
   SHAPE_OPTIONS,
   getFamilyModifiers,
@@ -2959,6 +2960,8 @@ if (typeof document !== 'undefined') {
         const alpha = metrics.alpha;
         if (alpha <= 0) continue;
 
+        const strokeWidth = computeNoteStrokeWidth(metrics.width, metrics.height);
+
         if (!released) {
           offscreenCtx.save();
           offscreenCtx.globalAlpha = alpha;
@@ -2985,6 +2988,7 @@ if (typeof document !== 'undefined') {
           metrics.width,
           metrics.height,
           true,
+          strokeWidth,
         );
         offscreenCtx.restore();
 
@@ -3030,6 +3034,8 @@ if (typeof document !== 'undefined') {
         const drawY = posY - height / 2;
         if (drawX > canvas.width || drawX + width < 0) return;
 
+        const strokeWidth = computeNoteStrokeWidth(width, height);
+
         if (currentSec < note.end) {
           offscreenCtx.save();
           offscreenCtx.globalAlpha = alpha;
@@ -3041,7 +3047,7 @@ if (typeof document !== 'undefined') {
         offscreenCtx.save();
         offscreenCtx.globalAlpha = alpha;
         offscreenCtx.strokeStyle = note.color;
-        drawNoteShape(offscreenCtx, note.shape, drawX, drawY, width, height, true);
+        drawNoteShape(offscreenCtx, note.shape, drawX, drawY, width, height, true, strokeWidth);
         offscreenCtx.restore();
       });
 
@@ -3109,13 +3115,13 @@ const FAMILY_DEFAULTS = {
   'Saxofones': { shape: 'star', color: '#a0522d' },
   Metales: { shape: 'capsule', color: '#ffff00' },
   Cornos: { shape: 'capsule', color: '#ffff00' },
-  'Percusión menor': { shape: 'pentagon', color: '#808080' },
+  'Percusión menor': { shape: 'square', color: '#808080' },
   Tambores: { shape: 'circle', color: '#808080' },
   Platillos: { shape: 'circle', color: '#808080' },
   Placas: { shape: 'square', color: '#ff0000' },
   Auxiliares: { shape: 'circle', color: '#4b0082' },
   'Cuerdas frotadas': { shape: 'diamond', color: '#ffa500' },
-  'Cuerdas pulsadas': { shape: 'star4', color: '#008000' },
+  'Cuerdas pulsadas': { shape: 'circle', color: '#008000' },
   Voces: { shape: 'capsule', color: '#808080' },
   'Custom 1': { shape: 'square', color: '#ffffff' },
   'Custom 2': { shape: 'square', color: '#ffffff' },
@@ -3630,6 +3636,7 @@ if (typeof module !== 'undefined') {
     computeBumpHeight,
     computeGlowAlpha,
     applyGlowEffect,
+    computeNoteStrokeWidth,
     computeSeekOffset,
     resetStartOffset,
     drawNoteShape,

--- a/test_shapes.js
+++ b/test_shapes.js
@@ -11,6 +11,10 @@ function stubCtx() {
     moveToCalled: false,
     strokeCalled: false,
     fillCalled: false,
+    lineWidth: 1,
+    lineJoin: 'miter',
+    lineCap: 'butt',
+    miterLimit: 2,
   };
   ctx.beginPath = () => {
     ctx.beginPathCalled = true;
@@ -47,8 +51,6 @@ const shapes = [
   ['square', 'rectCalled'],
   ['diamond', 'lineToCalled'],
   ['star', 'lineToCalled'],
-  ['star4', 'lineToCalled'],
-  ['pentagon', 'lineToCalled'],
 ];
 
 shapes.forEach(([shape, expected]) => {
@@ -100,5 +102,20 @@ const minX = Math.min(...xs);
 const maxX = Math.max(...xs);
 assert.strictEqual(minX, 0, 'diamante alargado no alineado a la izquierda');
 assert.strictEqual(maxX, 20, 'diamante alargado no alineado a la derecha');
+
+// Verificación del grosor dinámico del contorno
+const strokeCtx = stubCtx();
+drawNoteShape(strokeCtx, 'oval', 0, 0, 40, 10, true);
+assert(strokeCtx.strokeCalled, 'stroke no llamado para contorno');
+assert(strokeCtx.lineWidth > 1.35, 'grosor de contorno insuficiente');
+assert.strictEqual(strokeCtx.lineJoin, 'round', 'lineJoin incorrecto para figura suave');
+assert.strictEqual(strokeCtx.lineCap, 'round', 'lineCap incorrecto para figura suave');
+assert.strictEqual(strokeCtx.miterLimit, 4, 'miterLimit inesperado en figura suave');
+
+const starStrokeCtx = stubCtx();
+drawNoteShape(starStrokeCtx, 'star', 0, 0, 40, 20, true);
+assert.strictEqual(starStrokeCtx.lineJoin, 'miter', 'lineJoin incorrecto para estrella');
+assert.strictEqual(starStrokeCtx.miterLimit, 8, 'miterLimit incorrecto para estrella');
+assert.strictEqual(starStrokeCtx.lineCap, 'butt', 'lineCap incorrecto para estrella');
 
 console.log('Pruebas de figuras geométricas completadas');


### PR DESCRIPTION
## Summary
- refine contour rendering by computing dynamic stroke widths and applying stroke styles for note outlines
- replace the retired star4 and pentagon figures in family defaults and configuration presets with supported shapes
- update tests and selectable shape options to reflect the streamlined shape set

## Testing
- node test_shapes.js
- node test_config_export_import.js
- node test_family_customization.js
- node test_family_dropdown_custom.js

------
https://chatgpt.com/codex/tasks/task_e_68f525e795508333a364ea76dcdf5b1f