### PR TITLE
Adjust global visualization defaults

### DIFF
--- a/configuracion.js
+++ b/configuracion.js
@@ -264,22 +264,16 @@ window.DEFAULT_CONFIG = {
     "mid": 0.5
   },
   "glowStrength": 1,
-  "bumpControl": 1.2,
-  "visibleSeconds": 6,
+  "bumpControl": 1,
+  "visibleSeconds": 8,
   "heightScale": {
     "global": 1,
-    "families": {
-      "Cuerdas frotadas": 4,
-      "Cuerdas pulsadas": 1.5,
-      "Dobles cañas": 0.8,
-      "Auxiliares": 0.2,
-      "Percusión menor": 3
-    }
+    "families": {}
   },
   "shapeExtensions": {
-    "oval": false,
-    "capsule": false,
-    "star": false,
+    "oval": true,
+    "capsule": true,
+    "star": true,
     "diamond": true
   }
 };

--- a/configuracion.json
+++ b/configuracion.json
@@ -264,22 +264,16 @@
     "mid": 0.5
   },
   "glowStrength": 1,
-  "bumpControl": 1.2,
-  "visibleSeconds": 6,
+  "bumpControl": 1,
+  "visibleSeconds": 8,
   "heightScale": {
     "global": 1,
-    "families": {
-      "Cuerdas frotadas": 4,
-      "Cuerdas pulsadas": 1.5,
-      "Dobles cañas": 0.8,
-      "Auxiliares": 0.2,
-      "Percusión menor": 3
-    }
+    "families": {}
   },
   "shapeExtensions": {
-    "oval": false,
-    "capsule": false,
-    "star": false,
+    "oval": true,
+    "capsule": true,
+    "star": true,
     "diamond": true
   }
 }

--- a/script.js
+++ b/script.js
@@ -109,7 +109,7 @@ function setInstrumentEnabled(inst, enabled) {
   }
 }
 
-let visibleSeconds = 6;
+let visibleSeconds = 8;
 let canvas = null;
 let pixelsPerSecond = 0;
 let audioOffsetMs = 0;
@@ -1450,7 +1450,7 @@ if (typeof document !== 'undefined') {
     function updateTrackFamily(trackName, fam) {
       const track = currentTracks.find((t) => t.name === trackName);
       const preset =
-        FAMILY_PRESETS[fam] || { shape: 'unknown', color: '#ffffff' };
+        FAMILY_PRESETS[fam] || { shape: 'oval', color: '#ffa500' };
       if (track) {
         track.family = fam;
         track.shape = preset.shape;
@@ -1530,14 +1530,14 @@ if (typeof document !== 'undefined') {
         let mixed = false;
         families.forEach((family) => {
           const preset = FAMILY_PRESETS[family] || {};
-          const color = preset.color || '#ffffff';
+          const color = preset.color || '#ffa500';
           if (baseColor === null) {
             baseColor = color;
           } else if (baseColor.toLowerCase() !== color.toLowerCase()) {
             mixed = true;
           }
         });
-        if (baseColor === null) baseColor = '#ffffff';
+        if (baseColor === null) baseColor = '#ffa500';
         return { color: baseColor, mixed };
       };
 
@@ -2854,8 +2854,8 @@ if (typeof document !== 'undefined') {
               end,
               noteNumber: ev.noteNumber,
               velocity: ev.velocity,
-              color: track.color || '#ffffff',
-              shape: track.shape || 'square',
+              color: track.color || '#ffa500',
+              shape: track.shape || 'oval',
               family: track.family,
               instrument: track.instrument,
               trackName: track.name,
@@ -3367,7 +3367,7 @@ function setFamilyCustomization(
   tracks = [],
   notes = []
 ) {
-  const basePreset = FAMILY_PRESETS[family] || { shape: 'square', color: '#ffffff' };
+  const basePreset = FAMILY_PRESETS[family] || { shape: 'oval', color: '#ffa500' };
   const preset = { ...basePreset };
   let resolvedColor = color;
   if (!resolvedColor && colorBright && colorDark) {
@@ -3410,12 +3410,12 @@ function resetFamilyCustomizations(tracks = [], notes = []) {
   resetFamilyLineSettings();
   resetTravelEffectSettings();
   tracks.forEach((t) => {
-    const preset = FAMILY_PRESETS[t.family] || { shape: 'square', color: '#ffffff' };
+    const preset = FAMILY_PRESETS[t.family] || { shape: 'oval', color: '#ffa500' };
     t.shape = preset.shape;
     t.color = getInstrumentColor(preset);
   });
   notes.forEach((n) => {
-    const preset = FAMILY_PRESETS[n.family] || { shape: 'square', color: '#ffffff' };
+    const preset = FAMILY_PRESETS[n.family] || { shape: 'oval', color: '#ffa500' };
     n.shape = preset.shape;
     n.color = getInstrumentColor(preset);
   });
@@ -3557,7 +3557,7 @@ function importConfiguration(json, tracks = [], notes = []) {
     const fam = assignedFamilies[t.name] || t.family;
     t.family = fam;
     const preset =
-      FAMILY_PRESETS[fam] || { shape: 'unknown', color: '#ffffff' };
+      FAMILY_PRESETS[fam] || { shape: 'oval', color: '#ffa500' };
     t.shape = preset.shape;
     t.color = getInstrumentColor(preset);
   });
@@ -3566,7 +3566,7 @@ function importConfiguration(json, tracks = [], notes = []) {
     const fam = assignedFamilies[key] || n.family;
     n.family = fam;
     const preset =
-      FAMILY_PRESETS[fam] || { shape: 'unknown', color: '#ffffff' };
+      FAMILY_PRESETS[fam] || { shape: 'oval', color: '#ffa500' };
     n.shape = preset.shape;
     n.color = getInstrumentColor(preset);
   });
@@ -3603,7 +3603,7 @@ function assignTrackInfo(tracks) {
   return tracks.map((t) => {
     const instrument = resolveInstrumentName(t.name);
     const family = INSTRUMENT_FAMILIES[instrument] || 'Desconocida';
-    const preset = FAMILY_PRESETS[family] || { shape: 'unknown', color: '#ffffff' };
+    const preset = FAMILY_PRESETS[family] || { shape: 'oval', color: '#ffa500' };
     const color = getInstrumentColor(preset);
     return { ...t, instrument, family, shape: preset.shape, color };
   });

--- a/test_velocity_height.js
+++ b/test_velocity_height.js
@@ -2,13 +2,13 @@ const assert = require('assert');
 const { computeVelocityHeight, computeBumpHeight } = require('./script');
 
 const base = 10;
-assert.strictEqual(computeVelocityHeight(base, 67), base);
-assert.strictEqual(computeVelocityHeight(base, 134), base * 2);
-assert(Math.abs(computeVelocityHeight(base, 33) - base * (33 / 67)) < 1e-6);
+assert.strictEqual(computeVelocityHeight(base, 127), base);
+assert.strictEqual(computeVelocityHeight(base, 254), base * 2);
+assert(Math.abs(computeVelocityHeight(base, 33) - base * (33 / 127)) < 1e-6);
 
 // Verifica que la altura del bump también escala con la velocidad
-const bumpBase = computeBumpHeight(computeVelocityHeight(base, 67), 0, 0, 1);
-const bumpDouble = computeBumpHeight(computeVelocityHeight(base, 134), 0, 0, 1);
+const bumpBase = computeBumpHeight(computeVelocityHeight(base, 127), 0, 0, 1);
+const bumpDouble = computeBumpHeight(computeVelocityHeight(base, 254), 0, 0, 1);
 assert.strictEqual(bumpDouble, bumpBase * 2);
 
 console.log('Pruebas de altura por velocidad completadas');

--- a/utils.js
+++ b/utils.js
@@ -209,7 +209,7 @@ function computeBumpHeight(baseHeight, currentSec, start, end, bump = 0.5, famil
 }
 
 // Referencia de velocidad MIDI para altura 100%
-let velocityBase = 67;
+let velocityBase = 127;
 
 // Permite definir una nueva velocidad base
 function setVelocityBase(value) {
@@ -287,7 +287,7 @@ function getHeightScaleConfig() {
 loadHeightScale();
 
 // Escala global o por familia para el grosor del contorno tras el NOTE OFF
-let contourWidthScale = 1;
+let contourWidthScale = 0.6;
 let familyContourWidthScale = {};
 
 function persistContourWidthScale() {
@@ -698,7 +698,7 @@ function isExtensionEnabledForFamily(shape, family) {
 
 loadShapeExtensions();
 
-const DEFAULT_LINE_SETTINGS = { enabled: false, opacity: 0.45, width: 1.5 };
+const DEFAULT_LINE_SETTINGS = { enabled: true, opacity: 0.3, width: 8 };
 let familyLineSettings = {};
 let familyTravelSettings = {};
 const DEFAULT_TRAVEL_EFFECT = true;


### PR DESCRIPTION
## Summary
- set the default visible time window to 8 seconds and update fallback note styling to an oval with #FFA500
- refresh the bundled configuration so bump, height, glow, dynamic extensions, and connection lines start with the requested defaults
- raise the default MIDI velocity reference and connection line settings to match the new specification

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f530a8a46c833381adb12c8432a888