### PR TITLE
Improve YouTube loader API fallbacks

### DIFF
--- a/test_youtube_loader.js
+++ b/test_youtube_loader.js
@@ -22,7 +22,7 @@ const { loadYouTubeMedia, extractYouTubeId } = require('./youtubeLoader.js');
   };
 
   const fetcher = async (url) => {
-    if (url === 'https://piped.video/api/v1/streams/abcdefghijk') {
+    if (url.startsWith('https://piped.video/api/v1/streams/abcdefghijk')) {
       return {
         ok: true,
         json: async () => ({
@@ -81,7 +81,7 @@ const { loadYouTubeMedia, extractYouTubeId } = require('./youtubeLoader.js');
   assert.strictEqual(Math.round(result.duration), 12);
 
   const failingFetcher = async (url) => {
-    if (url === 'https://piped.video/api/v1/streams/abcdefghijk') {
+    if (url.startsWith('https://piped.video/api/v1/streams/abcdefghijk')) {
       return {
         ok: true,
         text: async () => '<!DOCTYPE html><html><body>Error</body></html>',


### PR DESCRIPTION
## Summary
- prefer Piped endpoints that expose proxied audio streams and support templated API base URLs
- add a fetch wrapper that always requests JSON responses when loading YouTube metadata
- update the YouTube loader unit test to cover the new fallback handling

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68fa1c9e18248333b2811392c2be59d3