### PR TITLE
Remove background video controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,27 +80,7 @@
     >Pantalla completa</button>
   </nav>
 
-  <label id="video-opacity-control">
-    Opacidad video
-    <input
-      type="range"
-      id="video-opacity"
-      min="0"
-      max="100"
-      value="40"
-      title="Ajusta la opacidad del video de fondo"
-    />
-    <span id="video-opacity-value">40%</span>
-  </label>
-
   <div id="visual-stage">
-    <video
-      id="background-video"
-      preload="auto"
-      muted
-      playsinline
-      class="hidden"
-    ></video>
     <canvas
       id="visualizer"
       width="1280"

--- a/styles.css
+++ b/styles.css
@@ -43,29 +43,6 @@ body {
   border-radius: 6px;
 }
 
-#video-opacity-control {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 0.85rem;
-  background: #1a1a1a;
-  padding: 12px;
-  border-radius: 6px;
-  margin: 0 10px 10px;
-  width: calc(100% - 20px);
-  box-sizing: border-box;
-}
-
-#video-opacity-control input[type='range'] {
-  flex: 1;
-}
-
-#video-opacity-value {
-  min-width: 48px;
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-}
-
 #visual-stage {
   position: relative;
   margin: 10px;
@@ -77,18 +54,6 @@ body {
   display: block;
   position: relative;
   z-index: 1;
-}
-
-#background-video {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  pointer-events: none;
-  opacity: 0;
-  z-index: 0;
 }
 
 /* Layout específico para el menú inferior para mantener


### PR DESCRIPTION
## Summary
- remove the background video element and opacity slider from the main layout
- delete styling tied to the removed controls
- strip all background video handling logic so playback relies solely on the canvas and optional images

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fa263f6eb08333b7f41ed6f5d1b482