### PR TITLE
Make advanced controls always visible and tune visual defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,12 +107,7 @@
       id="toggle-family-panel"
       title="Panel de familias"
       data-help="Despliega el panel para personalizar color y figura de cada familia."
-    >▼</button>
-    <button
-      id="developer-mode"
-      title="Modo desarrollador"
-      data-help="Activa controles avanzados y muestra mensajes de ayuda detallados."
-    >Modo desarrollador</button>
+    >▲</button>
     <button
       id="tap-tempo-mode"
       title="Modo tap tempo"
@@ -120,8 +115,8 @@
     >Modo tap tempo</button>
   </nav>
 
-  <div id="family-config-panel" class="hidden">
-    <div id="developer-controls" class="hidden"></div>
+  <div id="family-config-panel" class="active">
+    <div id="developer-controls"></div>
   </div>
 
   <div id="tap-tempo-panel" class="hidden">

--- a/styles.css
+++ b/styles.css
@@ -48,7 +48,6 @@ body {
   text-align: center;
 }
 
-#developer-mode,
 #tap-tempo-mode {
   flex: 1 1 160px;
   min-width: 150px;

--- a/test_canvas_color.js
+++ b/test_canvas_color.js
@@ -16,7 +16,6 @@ const dom = new JSDOM(`<!DOCTYPE html><html><body>
 <span id="family-bump-value"></span>
 <input type="checkbox" id="family-extension-toggle" />
 <button id="toggle-family-panel"></button>
-<button id="developer-mode"></button>
 <div id="family-config-panel"><div id="developer-controls"></div></div>
 <div id="assignment-modal"></div>
 <div id="modal-instrument-list"></div>

--- a/test_config_export_import.js
+++ b/test_config_export_import.js
@@ -40,22 +40,22 @@ const config = {
   contourWidth: { global: 1.5, families: { Metales: 1.2 } },
   contourOpacity: { global: 1, families: {} },
   visibleSeconds: 6,
-  heightScale: { global: 1, families: {} },
+  heightScale: { global: 2, families: {} },
   shapeExtensions: {
     circle: true,
-    circleDouble: true,
+    circleDouble: false,
     square: true,
-    squareDouble: true,
+    squareDouble: false,
     roundedSquare: true,
-    roundedSquareDouble: true,
+    roundedSquareDouble: false,
     diamond: true,
-    diamondDouble: true,
+    diamondDouble: false,
     fourPointStar: true,
-    fourPointStarDouble: true,
-    sixPointStar: true,
-    sixPointStarDouble: true,
+    fourPointStarDouble: false,
+    sixPointStar: false,
+    sixPointStarDouble: false,
     triangle: true,
-    triangleDouble: true,
+    triangleDouble: false,
   },
   familyExtensions: { Metales: true },
   familyLineSettings: {},
@@ -82,7 +82,7 @@ assert.strictEqual(getBumpControl('Metales'), 1.1);
 assert.strictEqual(getContourWidthScale(), 1.5);
 assert.strictEqual(getContourWidthScale('Metales'), 1.2);
 assert.strictEqual(getVisibleSeconds(), 6);
-assert.deepStrictEqual(getHeightScaleConfig(), { global: 1, families: {} });
+assert.deepStrictEqual(getHeightScaleConfig(), { global: 2, families: {} });
 
 const exported = JSON.parse(exportConfiguration());
 assert.deepStrictEqual(exported, config);

--- a/test_menu_accessibility.js
+++ b/test_menu_accessibility.js
@@ -29,7 +29,6 @@ const dom = new JSDOM(`<!DOCTYPE html><html><body>
 <input type="checkbox" id="family-extension-toggle" />
 <nav id="bottom-menu">
   <button id="toggle-family-panel"></button>
-  <button id="developer-mode"></button>
   <button id="tap-tempo-mode"></button>
 </nav>
 <div id="family-config-panel"><div id="developer-controls"></div></div>

--- a/test_modal_shift_selection.js
+++ b/test_modal_shift_selection.js
@@ -16,7 +16,6 @@ const dom = new JSDOM(`<!DOCTYPE html><html><body>
 <span id="family-bump-value"></span>
 <input type="checkbox" id="family-extension-toggle" />
 <button id="toggle-family-panel"></button>
-<button id="developer-mode"></button>
 <div id="family-config-panel"><div id="developer-controls"></div></div>
 <div id="assignment-modal">
   <ul id="modal-instrument-list">

--- a/test_multi_drag.js
+++ b/test_multi_drag.js
@@ -69,7 +69,6 @@ const dom = new JSDOM(`<!DOCTYPE html><html><body>
 <span id="family-bump-value"></span>
 <input type="checkbox" id="family-extension-toggle" />
 <button id="toggle-family-panel"></button>
-<button id="developer-mode"></button>
 <div id="family-config-panel"><div id="developer-controls"></div></div>
 <div id="assignment-modal">
   <ul id="modal-instrument-list"></ul>

--- a/test_offscreen_render.js
+++ b/test_offscreen_render.js
@@ -16,7 +16,6 @@ const dom = new JSDOM(`<!DOCTYPE html><html><body>
 <span id="family-bump-value"></span>
 <input type="checkbox" id="family-extension-toggle" />
 <button id="toggle-family-panel"></button>
-<button id="developer-mode"></button>
 <div id="family-config-panel"><div id="developer-controls"></div></div>
 <div id="assignment-modal"></div>
 <div id="modal-instrument-list"></div>

--- a/test_velocity_note_render.js
+++ b/test_velocity_note_render.js
@@ -16,7 +16,6 @@ const dom = new JSDOM(`<!DOCTYPE html><html><body>
 <span id="family-bump-value"></span>
 <input type="checkbox" id="family-extension-toggle" />
 <button id="toggle-family-panel"></button>
-<button id="developer-mode"></button>
 <div id="family-config-panel"><div id="developer-controls"></div></div>
 <div id="assignment-modal"></div>
 <div id="modal-instrument-list"></div>


### PR DESCRIPTION
## Summary
- remove the developer mode toggle so the family controls stay visible by default while keeping tap tempo available
- raise the default height, glow, and bump multipliers, disable contours and connection lines by default, and shrink the innermost layer of double figures
- prevent dynamic extensions on double figures and six-point stars and update tests to match the new layout and defaults

## Testing
- npm test *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68faafa13f2c8333bc72c33d372944fb