### PR TITLE
Disable contour customization and block double shape stretching

### DIFF
--- a/test_config_export_import.js
+++ b/test_config_export_import.js
@@ -7,7 +7,6 @@ const {
   getOpacityScale,
   getGlowStrength,
   getBumpControl,
-  getContourWidthScale,
   getVisibleSeconds,
   getHeightScaleConfig,
 } = require('./script.js');
@@ -37,8 +36,6 @@ const config = {
   opacityScale: { edge: 0.1, mid: 0.8 },
   glowStrength: { global: 1.5, families: { Metales: 1.2 } },
   bumpControl: { global: 1.2, families: { Metales: 1.1 } },
-  contourWidth: { global: 1.5, families: { Metales: 1.2 } },
-  contourOpacity: { global: 1, families: {} },
   visibleSeconds: 6,
   heightScale: { global: 2, families: {} },
   shapeExtensions: {
@@ -79,8 +76,6 @@ assert.strictEqual(getGlowStrength(), 1.5);
 assert.strictEqual(getGlowStrength('Metales'), 1.2);
 assert.strictEqual(getBumpControl(), 1.2);
 assert.strictEqual(getBumpControl('Metales'), 1.1);
-assert.strictEqual(getContourWidthScale(), 1.5);
-assert.strictEqual(getContourWidthScale('Metales'), 1.2);
 assert.strictEqual(getVisibleSeconds(), 6);
 assert.deepStrictEqual(getHeightScaleConfig(), { global: 2, families: {} });
 


### PR DESCRIPTION
## Summary
- remove contour width and opacity controls from the family configuration UI and exported data
- disable contour rendering helpers so figures are always drawn without outlines
- prevent dynamic stretching on every double shape name via a shared detection rule

## Testing
- node test_config_export_import.js
- node test_glow_control.js
- node test_bump_control.js
- node test_height_scale.js

------
https://chatgpt.com/codex/tasks/task_e_68fac3f0650883339c00e729783cdd94