### PR TITLE
Align visual defaults and sync render loop with display refresh

### DIFF
--- a/configuracion.js
+++ b/configuracion.js
@@ -275,11 +275,11 @@ window.DEFAULT_CONFIG = {
     "edge": 0,
     "mid": 0.5
   },
-  "glowStrength": 1,
-  "bumpControl": 1,
+  "glowStrength": 1.5,
+  "bumpControl": 1.2,
   "visibleSeconds": 8,
   "heightScale": {
-    "global": 1,
+    "global": 2,
     "families": {}
   },
   "shapeExtensions": {

--- a/configuracion.json
+++ b/configuracion.json
@@ -275,11 +275,11 @@
     "edge": 0,
     "mid": 0.5
   },
-  "glowStrength": 1,
-  "bumpControl": 1,
+  "glowStrength": 1.5,
+  "bumpControl": 1.2,
   "visibleSeconds": 8,
   "heightScale": {
-    "global": 1,
+    "global": 2,
     "families": {}
   },
   "shapeExtensions": {

--- a/renderLoop.js
+++ b/renderLoop.js
@@ -1,6 +1,6 @@
 // Motor de renderizado basado en requestAnimationFrame
 // Proporciona una cola de eventos para noteOn/noteOff y un bucle principal
-// que procesa eventos en batch y entrega dt clamped al callback de renderizado.
+// que procesa eventos en batch y entrega dt sincronizado con requestAnimationFrame.
 
 function createRenderState(maxBatch = 200) {
   return {
@@ -84,7 +84,11 @@ function processEventQueue(state, handler) {
 function startRenderLoop(state, render, handleEvent) {
   let last = performance.now();
   function frame(now) {
-    const dt = Math.min(Math.max(now - last, 8), 32);
+    const delta = now - last;
+    let dt = 0;
+    if (Number.isFinite(delta) && delta > 0) {
+      dt = delta > 250 ? 250 : delta;
+    }
     last = now;
     processEventQueue(state, handleEvent);
     if (render) render(dt, now, state);

--- a/test_auto_fps.js
+++ b/test_auto_fps.js
@@ -29,9 +29,9 @@ rafCallback(5);
 rafCallback(30);
 
 assert.strictEqual(deltas.length, 3);
-assert.strictEqual(deltas[0], 10);
-assert.strictEqual(deltas[1], 10);
-assert.strictEqual(deltas[2], 20);
+assert.strictEqual(deltas[0], 0);
+assert.strictEqual(deltas[1], 5);
+assert.strictEqual(deltas[2], 25);
 
 stop();
 assert(canceled);

--- a/test_family_modifiers.js
+++ b/test_family_modifiers.js
@@ -14,9 +14,9 @@ assert.strictEqual(defaultMods.sizeFactor, 1);
 
 // Cálculo del ancho para figuras no alargadas
 const notePlatillos = { start: 0, end: 1, shape: 'circle', family: 'Platillos' };
-assert.strictEqual(computeNoteWidth(notePlatillos, 10, 20), 13);
+assert.strictEqual(computeNoteWidth(notePlatillos, 10, 20), 26);
 
 const noteTambores = { start: 0, end: 1, shape: 'circle', family: 'Tambores' };
-assert.strictEqual(computeNoteWidth(noteTambores, 10, 20), 10);
+assert.strictEqual(computeNoteWidth(noteTambores, 10, 20), 20);
 
 console.log('Pruebas de modificadores de familia completadas');

--- a/test_velocity_note_render.js
+++ b/test_velocity_note_render.js
@@ -67,7 +67,7 @@ dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
 const canvas = dom.window.document.getElementById('visualizer');
 const noteHeight = canvas.height / 88;
 const sizeFactor = script.getFamilyModifiers('Metales').sizeFactor;
-const baseHeight = noteHeight * sizeFactor;
+const baseHeight = noteHeight * sizeFactor * script.getHeightScale('Metales');
 const velBase = script.getVelocityBase();
 
 const notes = [
@@ -77,7 +77,7 @@ const notes = [
 
 dom.window.__setTestNotes(notes);
 
-dom.window.__renderFrame(1.1);
+dom.window.__renderFrame(1.3);
 
 const rects = contexts[1].rects;
 assert.strictEqual(rects.length, 2, 'Debe dibujar dos rectángulos de contorno tras el note off');

--- a/test_visual_effects.js
+++ b/test_visual_effects.js
@@ -24,15 +24,15 @@ setOpacityScale(0, 0.5);
 // Pruebas para computeBumpHeight
 const base = 10;
 approx(computeBumpHeight(base, -0.1, 0, 1), base); // Antes de la nota
-approx(computeBumpHeight(base, 0, 0, 1), 15); // En el NOTE ON
-approx(computeBumpHeight(base, 0.5, 0, 1), 12.5); // Mitad del intervalo
-approx(computeBumpHeight(base, 1, 0, 1), base); // En el NOTE OFF
-approx(computeBumpHeight(base, 0, 0, 1, 0.8), 18); // Bump +30%
+approx(computeBumpHeight(base, 0, 0, 1), 16); // En el NOTE ON con bump 120%
+approx(computeBumpHeight(base, 0.5, 0, 1), 13.5); // Mitad del intervalo extendido
+approx(computeBumpHeight(base, 1.2, 0, 1), base); // Regreso tras la extensión del bump
+approx(computeBumpHeight(base, 0, 0, 1, 0.8), 19.6); // Bump incrementado
 
 // Pruebas para computeGlowAlpha
 approx(computeGlowAlpha(0, 0), 1); // Inicio del brillo
-approx(computeGlowAlpha(0.1, 0), 0.5); // Mitad del efecto
-approx(computeGlowAlpha(0.25, 0), 0); // Efecto terminado
+approx(computeGlowAlpha(0.1, 0), 2 / 3); // Mitad del efecto extendido
+approx(computeGlowAlpha(0.3, 0), 0); // Efecto terminado
 
 // Prueba para applyGlowEffect con desenfoque solo vertical
 setGlowStrength(1.5);

--- a/utils.js
+++ b/utils.js
@@ -400,8 +400,9 @@ function applyGlowEffect(ctx, shape, x, y, width, height, alpha, family) {
   ctx.restore();
 }
 
-function computeNoteStrokeWidth() {
-  return 0;
+function computeNoteStrokeWidth(width = 0, height = 0) {
+  const minDim = Math.max(Math.min(width, height), 1);
+  return Math.max(minDim / 6, 1.5);
 }
 
 function configureNoteStrokeStyle(ctx, shape, width, height, strokeWidth) {
@@ -438,6 +439,14 @@ function getScaledFrame(x, y, width, height, scale) {
   const nx = x + (width - w) / 2;
   const ny = y + (height - h) / 2;
   return { x: nx, y: ny, width: w, height: h };
+}
+
+function getCenteredSquareFrame(x, y, width, height, scale = 1) {
+  const size = Math.min(width, height);
+  const scaled = size * scale;
+  const nx = x + (width - scaled) / 2;
+  const ny = y + (height - scaled) / 2;
+  return { x: nx, y: ny, width: scaled, height: scaled };
 }
 
 function traceRoundedSquare(ctx, x, y, width, height, radius) {
@@ -542,25 +551,29 @@ const SHAPE_METADATA = {
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          traceEllipse(ctx, x, y, width, height);
+          const frame = getCenteredSquareFrame(x, y, width, height);
+          traceEllipse(ctx, frame.x, frame.y, frame.width, frame.height);
         },
       },
       {
         color: 'secondary',
         draw(ctx, x, y, width, height) {
-          traceEllipse(ctx, x, y, width, height, 0.7);
+          const frame = getCenteredSquareFrame(x, y, width, height, 0.7);
+          traceEllipse(ctx, frame.x, frame.y, frame.width, frame.height);
         },
       },
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          traceEllipse(ctx, x, y, width, height, 0.396);
+          const frame = getCenteredSquareFrame(x, y, width, height, 0.396);
+          traceEllipse(ctx, frame.x, frame.y, frame.width, frame.height);
         },
       },
     ],
     secondaryFill: '#000000',
     draw(ctx, x, y, width, height) {
-      traceEllipse(ctx, x, y, width, height);
+      const frame = getCenteredSquareFrame(x, y, width, height);
+      traceEllipse(ctx, frame.x, frame.y, frame.width, frame.height);
     },
   },
   square: {
@@ -577,27 +590,29 @@ const SHAPE_METADATA = {
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          ctx.rect(x, y, width, height);
+          const frame = getCenteredSquareFrame(x, y, width, height);
+          ctx.rect(frame.x, frame.y, frame.width, frame.height);
         },
       },
       {
         color: 'secondary',
         draw(ctx, x, y, width, height) {
-          const frame = getScaledFrame(x, y, width, height, 0.72);
+          const frame = getCenteredSquareFrame(x, y, width, height, 0.72);
           ctx.rect(frame.x, frame.y, frame.width, frame.height);
         },
       },
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          const frame = getScaledFrame(x, y, width, height, 0.405);
+          const frame = getCenteredSquareFrame(x, y, width, height, 0.405);
           ctx.rect(frame.x, frame.y, frame.width, frame.height);
         },
       },
     ],
     secondaryFill: '#000000',
     draw(ctx, x, y, width, height) {
-      ctx.rect(x, y, width, height);
+      const frame = getCenteredSquareFrame(x, y, width, height);
+      ctx.rect(frame.x, frame.y, frame.width, frame.height);
     },
   },
   roundedSquare: {
@@ -612,31 +627,33 @@ const SHAPE_METADATA = {
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          const radius = Math.min(width, height) * 0.25;
-          traceRoundedSquare(ctx, x, y, width, height, radius);
+          const frame = getCenteredSquareFrame(x, y, width, height);
+          const radius = frame.width * 0.25;
+          traceRoundedSquare(ctx, frame.x, frame.y, frame.width, frame.height, radius);
         },
       },
       {
         color: 'secondary',
         draw(ctx, x, y, width, height) {
-          const frame = getScaledFrame(x, y, width, height, 0.72);
-          const radius = Math.min(frame.width, frame.height) * 0.25;
+          const frame = getCenteredSquareFrame(x, y, width, height, 0.72);
+          const radius = frame.width * 0.25;
           traceRoundedSquare(ctx, frame.x, frame.y, frame.width, frame.height, radius);
         },
       },
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          const frame = getScaledFrame(x, y, width, height, 0.414);
-          const radius = Math.min(frame.width, frame.height) * 0.25;
+          const frame = getCenteredSquareFrame(x, y, width, height, 0.414);
+          const radius = frame.width * 0.25;
           traceRoundedSquare(ctx, frame.x, frame.y, frame.width, frame.height, radius);
         },
       },
     ],
     secondaryFill: '#000000',
     draw(ctx, x, y, width, height) {
-      const radius = Math.min(width, height) * 0.25;
-      traceRoundedSquare(ctx, x, y, width, height, radius);
+      const frame = getCenteredSquareFrame(x, y, width, height);
+      const radius = frame.width * 0.25;
+      traceRoundedSquare(ctx, frame.x, frame.y, frame.width, frame.height, radius);
     },
   },
   diamond: {
@@ -653,31 +670,35 @@ const SHAPE_METADATA = {
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          traceDiamond(ctx, x, y, width, height);
+          const frame = getCenteredSquareFrame(x, y, width, height);
+          traceDiamond(ctx, frame.x, frame.y, frame.width, frame.height);
         },
       },
       {
         color: 'secondary',
         draw(ctx, x, y, width, height) {
-          traceDiamond(ctx, x, y, width, height, {
-            insetX: width * 0.16,
-            insetY: height * 0.16,
+          const frame = getCenteredSquareFrame(x, y, width, height);
+          traceDiamond(ctx, frame.x, frame.y, frame.width, frame.height, {
+            insetX: frame.width * 0.16,
+            insetY: frame.height * 0.16,
           });
         },
       },
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          traceDiamond(ctx, x, y, width, height, {
-            insetX: width * 0.352,
-            insetY: height * 0.352,
+          const frame = getCenteredSquareFrame(x, y, width, height);
+          traceDiamond(ctx, frame.x, frame.y, frame.width, frame.height, {
+            insetX: frame.width * 0.352,
+            insetY: frame.height * 0.352,
           });
         },
       },
     ],
     secondaryFill: '#000000',
     draw(ctx, x, y, width, height) {
-      traceDiamond(ctx, x, y, width, height);
+      const frame = getCenteredSquareFrame(x, y, width, height);
+      traceDiamond(ctx, frame.x, frame.y, frame.width, frame.height);
     },
   },
   fourPointStar: {
@@ -696,31 +717,35 @@ const SHAPE_METADATA = {
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          traceFourPointStar(ctx, x, y, width, height);
+          const frame = getCenteredSquareFrame(x, y, width, height);
+          traceFourPointStar(ctx, frame.x, frame.y, frame.width, frame.height);
         },
       },
       {
         color: 'secondary',
         draw(ctx, x, y, width, height) {
-          traceFourPointStar(ctx, x, y, width, height, {
-            insetX: width * 0.16,
-            insetY: height * 0.16,
+          const frame = getCenteredSquareFrame(x, y, width, height);
+          traceFourPointStar(ctx, frame.x, frame.y, frame.width, frame.height, {
+            insetX: frame.width * 0.16,
+            insetY: frame.height * 0.16,
           });
         },
       },
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          traceFourPointStar(ctx, x, y, width, height, {
-            insetX: width * 0.352,
-            insetY: height * 0.352,
+          const frame = getCenteredSquareFrame(x, y, width, height);
+          traceFourPointStar(ctx, frame.x, frame.y, frame.width, frame.height, {
+            insetX: frame.width * 0.352,
+            insetY: frame.height * 0.352,
           });
         },
       },
     ],
     secondaryFill: '#000000',
     draw(ctx, x, y, width, height) {
-      traceFourPointStar(ctx, x, y, width, height);
+      const frame = getCenteredSquareFrame(x, y, width, height);
+      traceFourPointStar(ctx, frame.x, frame.y, frame.width, frame.height);
     },
   },
   sixPointStar: {
@@ -734,30 +759,34 @@ const SHAPE_METADATA = {
     label: 'Estrella de 6 puntas doble',
     sharp: true,
     draw(ctx, x, y, width, height) {
-      traceSixPointStar(ctx, x, y, width, height);
+      const frame = getCenteredSquareFrame(x, y, width, height);
+      traceSixPointStar(ctx, frame.x, frame.y, frame.width, frame.height);
     },
     layers: [
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          traceSixPointStar(ctx, x, y, width, height);
+          const frame = getCenteredSquareFrame(x, y, width, height);
+          traceSixPointStar(ctx, frame.x, frame.y, frame.width, frame.height);
         },
       },
       {
         color: 'secondary',
         draw(ctx, x, y, width, height) {
-          traceSixPointStar(ctx, x, y, width, height, {
-            insetX: width * 0.16,
-            insetY: height * 0.16,
+          const frame = getCenteredSquareFrame(x, y, width, height);
+          traceSixPointStar(ctx, frame.x, frame.y, frame.width, frame.height, {
+            insetX: frame.width * 0.16,
+            insetY: frame.height * 0.16,
           });
         },
       },
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          traceSixPointStar(ctx, x, y, width, height, {
-            insetX: width * 0.352,
-            insetY: height * 0.352,
+          const frame = getCenteredSquareFrame(x, y, width, height);
+          traceSixPointStar(ctx, frame.x, frame.y, frame.width, frame.height, {
+            insetX: frame.width * 0.352,
+            insetY: frame.height * 0.352,
           });
         },
       },
@@ -778,31 +807,35 @@ const SHAPE_METADATA = {
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          traceTriangle(ctx, x, y, width, height);
+          const frame = getCenteredSquareFrame(x, y, width, height);
+          traceTriangle(ctx, frame.x, frame.y, frame.width, frame.height);
         },
       },
       {
         color: 'secondary',
         draw(ctx, x, y, width, height) {
-          traceTriangle(ctx, x, y, width, height, {
-            insetX: width * 0.18,
-            insetY: height * 0.18,
+          const frame = getCenteredSquareFrame(x, y, width, height);
+          traceTriangle(ctx, frame.x, frame.y, frame.width, frame.height, {
+            insetX: frame.width * 0.18,
+            insetY: frame.height * 0.18,
           });
         },
       },
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          traceTriangle(ctx, x, y, width, height, {
-            insetX: width * 0.352,
-            insetY: height * 0.352,
+          const frame = getCenteredSquareFrame(x, y, width, height);
+          traceTriangle(ctx, frame.x, frame.y, frame.width, frame.height, {
+            insetX: frame.width * 0.352,
+            insetY: frame.height * 0.352,
           });
         },
       },
     ],
     secondaryFill: '#000000',
     draw(ctx, x, y, width, height) {
-      traceTriangle(ctx, x, y, width, height);
+      const frame = getCenteredSquareFrame(x, y, width, height);
+      traceTriangle(ctx, frame.x, frame.y, frame.width, frame.height);
     },
   },
 };
@@ -1276,45 +1309,40 @@ function prefersReducedMotion() {
 
 function startAutoFPSLoop(callback, minDt = 8, maxDt = 32) {
   if (prefersReducedMotion()) {
-    callback(0, performance.now());
+    const now = performance.now();
+    callback(0, now);
     return () => {};
   }
 
   let last = performance.now();
-  let adaptiveMin = minDt;
-  let adaptiveMax = maxDt;
-  let sampleCount = 0;
-  let sampleTotal = 0;
+  let initialized = false;
   let id;
 
-  const clampDt = (value) => {
-    const lower = Math.min(Math.max(adaptiveMin, minDt), maxDt);
-    const upper = Math.max(lower, Math.min(adaptiveMax, maxDt));
-    return Math.min(Math.max(value, lower), upper);
-  };
+  const fallbackMin = Math.max(0, Number.isFinite(minDt) ? minDt : 0);
+  const fallbackMax = Math.max(fallbackMin, Number.isFinite(maxDt) ? maxDt : fallbackMin);
 
-  function updateAdaptiveWindow(delta) {
-    if (!Number.isFinite(delta) || delta <= 0) return;
-    sampleCount += 1;
-    sampleTotal += delta;
-    if (sampleCount > 120) {
-      sampleCount = Math.round(sampleCount / 2);
-      sampleTotal /= 2;
+  function computeDt(now) {
+    const delta = now - last;
+    last = now;
+    if (!Number.isFinite(delta) || delta <= 0) {
+      return fallbackMin;
     }
-    if (sampleCount < 5) return;
-    const average = sampleTotal / sampleCount;
-    const target = Math.min(Math.max(average, minDt), maxDt);
-    const span = target * 0.25;
-    adaptiveMin = Math.max(minDt, target - span);
-    adaptiveMax = Math.min(maxDt, target + span);
+    if (fallbackMax > 0 && delta > fallbackMax * 4) {
+      return fallbackMax;
+    }
+    return delta;
   }
 
   function frame(now) {
-    const delta = now - last;
-    updateAdaptiveWindow(delta);
-    const dt = clampDt(Number.isFinite(delta) ? delta : minDt);
-    last = now;
-    callback(dt, now);
+    const current = Number.isFinite(now) ? now : performance.now();
+    if (!initialized) {
+      last = current;
+      initialized = true;
+      callback(0, current);
+    } else {
+      const dt = computeDt(current);
+      callback(dt, current);
+    }
     id = requestAnimationFrame(frame);
   }
 


### PR DESCRIPTION
## Summary
- render double-layer shapes using centered square frames so their proportions remain uniform and tweak stroke width defaults
- update the default configuration to height 200%, glow 150%, and bump 120% while refreshing dependent unit tests
- let the render loop and auto FPS helper use requestAnimationFrame deltas directly, keeping the frame rate in step with the display

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fac6ef0a2c833398e9bb43b45eff33