### PR TITLE
Ensure glow and bump trigger when notes reach the present line

### DIFF
--- a/script.js
+++ b/script.js
@@ -3332,6 +3332,7 @@ if (typeof document !== 'undefined') {
           centerY,
           alignmentX,
           alignmentY,
+          activationX: rawXStart,
         };
       };
 
@@ -3438,7 +3439,7 @@ if (typeof document !== 'undefined') {
               note.start,
               0.2,
               note.family,
-              metrics.xStart,
+              metrics.activationX ?? metrics.xStart,
               canvas.width,
             )
           : 0;

--- a/utils.js
+++ b/utils.js
@@ -214,7 +214,7 @@ function computeBumpHeight(
   if (
     typeof alignmentX === 'number' &&
     typeof canvasWidth === 'number' &&
-    alignmentX > canvasWidth / 2 + 0.25
+    alignmentX > canvasWidth / 2 + 0.001
   ) {
     return baseHeight;
   }
@@ -405,13 +405,14 @@ function computeGlowAlpha(
     duration <= 0 ||
     (typeof alignmentX === 'number' &&
       typeof canvasWidth === 'number' &&
-      alignmentX > canvasWidth / 2 + 0.25)
+      alignmentX > canvasWidth / 2 + 0.001)
   ) {
     return 0;
   }
   if (currentSec < start || currentSec > start + duration) return 0;
   const progress = (currentSec - start) / duration;
-  return 1 - progress;
+  const clamped = Math.min(Math.max(progress, 0), 1);
+  return 1 - clamped;
 }
 
 // Aplica un efecto de brillo con desenfoque alrededor de la figura


### PR DESCRIPTION
## Summary
- track each note's raw leading edge to drive glow and bump activation
- delay glow and bump until the leading edge reaches the canvas center line and clamp their decay progression

## Testing
- node test_visual_effects.js
- node test_bump_control.js

------
https://chatgpt.com/codex/tasks/task_e_68fad46f8d2483338a47771c58adead5