### PR TITLE
Fix anchor for double note shapes

### DIFF
--- a/test_shapes.js
+++ b/test_shapes.js
@@ -136,6 +136,61 @@ const maxX = Math.max(...xs);
 assert.strictEqual(minX, 0, 'diamante alargado no alineado a la izquierda');
 assert.strictEqual(maxX, 20, 'diamante alargado no alineado a la derecha');
 
+// Verificación de alineación izquierda para figuras dobles extendidas
+const circleDoubleCtx = {
+  ellipses: [],
+  fillStyle: '#fff',
+  beginPath() {},
+  ellipse(cx, cy, rx, ry) {
+    this.ellipses.push({ cx, rx });
+  },
+  fill() {},
+};
+drawNoteShape(circleDoubleCtx, 'circleDouble', 0, 0, 20, 10);
+assert(circleDoubleCtx.ellipses.length > 0, 'no se dibujó la capa principal del círculo doble');
+const firstEllipse = circleDoubleCtx.ellipses[0];
+assert.strictEqual(
+  Math.round((firstEllipse.cx - firstEllipse.rx) * 1e6) / 1e6,
+  0,
+  'círculo doble no alineado a la izquierda',
+);
+
+const squareDoubleCtx = {
+  rects: [],
+  fillStyle: '#fff',
+  beginPath() {},
+  rect(x, y, width, height) {
+    this.rects.push({ x, width });
+  },
+  fill() {},
+};
+drawNoteShape(squareDoubleCtx, 'squareDouble', 0, 0, 20, 10);
+assert(squareDoubleCtx.rects.length > 0, 'no se dibujó la capa principal del cuadrado doble');
+assert.strictEqual(squareDoubleCtx.rects[0].x, 0, 'cuadrado doble no alineado a la izquierda');
+
+const triangleDoubleCtx = {
+  path: [],
+  fillStyle: '#fff',
+  beginPath() {
+    this.path = [];
+  },
+  moveTo(x, y) {
+    this.path.push([x, y]);
+  },
+  lineTo(x, y) {
+    this.path.push([x, y]);
+  },
+  closePath() {},
+  fill() {
+    if (this.path.length && typeof this.firstMinX === 'undefined') {
+      const xsTriangle = this.path.map((p) => p[0]);
+      this.firstMinX = Math.min(...xsTriangle);
+    }
+  },
+};
+drawNoteShape(triangleDoubleCtx, 'triangleDouble', 0, 0, 20, 10);
+assert.strictEqual(triangleDoubleCtx.firstMinX, 0, 'triángulo doble no alineado a la izquierda');
+
 // Verificación del grosor dinámico del contorno
 const strokeCtx = stubCtx();
 drawNoteShape(strokeCtx, 'circle', 0, 0, 40, 10, true);

--- a/utils.js
+++ b/utils.js
@@ -587,29 +587,25 @@ const SHAPE_METADATA = {
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height);
-          traceEllipse(ctx, frame.x, frame.y, frame.width, frame.height);
+          traceEllipse(ctx, x, y, width, height);
         },
       },
       {
         color: 'secondary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height, 0.7);
-          traceEllipse(ctx, frame.x, frame.y, frame.width, frame.height);
+          traceEllipse(ctx, x, y, width, height, 0.7);
         },
       },
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height, 0.396);
-          traceEllipse(ctx, frame.x, frame.y, frame.width, frame.height);
+          traceEllipse(ctx, x, y, width, height, 0.396);
         },
       },
     ],
     secondaryFill: '#000000',
     draw(ctx, x, y, width, height) {
-      const frame = getCenteredSquareFrame(x, y, width, height);
-      traceEllipse(ctx, frame.x, frame.y, frame.width, frame.height);
+      traceEllipse(ctx, x, y, width, height);
     },
   },
   square: {
@@ -626,29 +622,27 @@ const SHAPE_METADATA = {
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height);
-          ctx.rect(frame.x, frame.y, frame.width, frame.height);
+          ctx.rect(x, y, width, height);
         },
       },
       {
         color: 'secondary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height, 0.72);
+          const frame = getScaledFrame(x, y, width, height, 0.72);
           ctx.rect(frame.x, frame.y, frame.width, frame.height);
         },
       },
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height, 0.405);
+          const frame = getScaledFrame(x, y, width, height, 0.405);
           ctx.rect(frame.x, frame.y, frame.width, frame.height);
         },
       },
     ],
     secondaryFill: '#000000',
     draw(ctx, x, y, width, height) {
-      const frame = getCenteredSquareFrame(x, y, width, height);
-      ctx.rect(frame.x, frame.y, frame.width, frame.height);
+      ctx.rect(x, y, width, height);
     },
   },
   roundedSquare: {
@@ -663,33 +657,31 @@ const SHAPE_METADATA = {
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height);
-          const radius = frame.width * 0.25;
-          traceRoundedSquare(ctx, frame.x, frame.y, frame.width, frame.height, radius);
+          const radius = Math.min(width, height) * 0.25;
+          traceRoundedSquare(ctx, x, y, width, height, radius);
         },
       },
       {
         color: 'secondary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height, 0.72);
-          const radius = frame.width * 0.25;
+          const frame = getScaledFrame(x, y, width, height, 0.72);
+          const radius = Math.min(frame.width, frame.height) * 0.25;
           traceRoundedSquare(ctx, frame.x, frame.y, frame.width, frame.height, radius);
         },
       },
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height, 0.414);
-          const radius = frame.width * 0.25;
+          const frame = getScaledFrame(x, y, width, height, 0.414);
+          const radius = Math.min(frame.width, frame.height) * 0.25;
           traceRoundedSquare(ctx, frame.x, frame.y, frame.width, frame.height, radius);
         },
       },
     ],
     secondaryFill: '#000000',
     draw(ctx, x, y, width, height) {
-      const frame = getCenteredSquareFrame(x, y, width, height);
-      const radius = frame.width * 0.25;
-      traceRoundedSquare(ctx, frame.x, frame.y, frame.width, frame.height, radius);
+      const radius = Math.min(width, height) * 0.25;
+      traceRoundedSquare(ctx, x, y, width, height, radius);
     },
   },
   diamond: {
@@ -706,35 +698,31 @@ const SHAPE_METADATA = {
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height);
-          traceDiamond(ctx, frame.x, frame.y, frame.width, frame.height);
+          traceDiamond(ctx, x, y, width, height);
         },
       },
       {
         color: 'secondary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height);
-          traceDiamond(ctx, frame.x, frame.y, frame.width, frame.height, {
-            insetX: frame.width * 0.16,
-            insetY: frame.height * 0.16,
+          traceDiamond(ctx, x, y, width, height, {
+            insetX: width * 0.16,
+            insetY: height * 0.16,
           });
         },
       },
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height);
-          traceDiamond(ctx, frame.x, frame.y, frame.width, frame.height, {
-            insetX: frame.width * 0.352,
-            insetY: frame.height * 0.352,
+          traceDiamond(ctx, x, y, width, height, {
+            insetX: width * 0.352,
+            insetY: height * 0.352,
           });
         },
       },
     ],
     secondaryFill: '#000000',
     draw(ctx, x, y, width, height) {
-      const frame = getCenteredSquareFrame(x, y, width, height);
-      traceDiamond(ctx, frame.x, frame.y, frame.width, frame.height);
+      traceDiamond(ctx, x, y, width, height);
     },
   },
   fourPointStar: {
@@ -753,35 +741,31 @@ const SHAPE_METADATA = {
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height);
-          traceFourPointStar(ctx, frame.x, frame.y, frame.width, frame.height);
+          traceFourPointStar(ctx, x, y, width, height);
         },
       },
       {
         color: 'secondary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height);
-          traceFourPointStar(ctx, frame.x, frame.y, frame.width, frame.height, {
-            insetX: frame.width * 0.16,
-            insetY: frame.height * 0.16,
+          traceFourPointStar(ctx, x, y, width, height, {
+            insetX: width * 0.16,
+            insetY: height * 0.16,
           });
         },
       },
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height);
-          traceFourPointStar(ctx, frame.x, frame.y, frame.width, frame.height, {
-            insetX: frame.width * 0.352,
-            insetY: frame.height * 0.352,
+          traceFourPointStar(ctx, x, y, width, height, {
+            insetX: width * 0.352,
+            insetY: height * 0.352,
           });
         },
       },
     ],
     secondaryFill: '#000000',
     draw(ctx, x, y, width, height) {
-      const frame = getCenteredSquareFrame(x, y, width, height);
-      traceFourPointStar(ctx, frame.x, frame.y, frame.width, frame.height);
+      traceFourPointStar(ctx, x, y, width, height);
     },
   },
   sixPointStar: {
@@ -795,34 +779,30 @@ const SHAPE_METADATA = {
     label: 'Estrella de 6 puntas doble',
     sharp: true,
     draw(ctx, x, y, width, height) {
-      const frame = getCenteredSquareFrame(x, y, width, height);
-      traceSixPointStar(ctx, frame.x, frame.y, frame.width, frame.height);
+      traceSixPointStar(ctx, x, y, width, height);
     },
     layers: [
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height);
-          traceSixPointStar(ctx, frame.x, frame.y, frame.width, frame.height);
+          traceSixPointStar(ctx, x, y, width, height);
         },
       },
       {
         color: 'secondary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height);
-          traceSixPointStar(ctx, frame.x, frame.y, frame.width, frame.height, {
-            insetX: frame.width * 0.16,
-            insetY: frame.height * 0.16,
+          traceSixPointStar(ctx, x, y, width, height, {
+            insetX: width * 0.16,
+            insetY: height * 0.16,
           });
         },
       },
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height);
-          traceSixPointStar(ctx, frame.x, frame.y, frame.width, frame.height, {
-            insetX: frame.width * 0.352,
-            insetY: frame.height * 0.352,
+          traceSixPointStar(ctx, x, y, width, height, {
+            insetX: width * 0.352,
+            insetY: height * 0.352,
           });
         },
       },
@@ -843,35 +823,31 @@ const SHAPE_METADATA = {
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height);
-          traceTriangle(ctx, frame.x, frame.y, frame.width, frame.height);
+          traceTriangle(ctx, x, y, width, height);
         },
       },
       {
         color: 'secondary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height);
-          traceTriangle(ctx, frame.x, frame.y, frame.width, frame.height, {
-            insetX: frame.width * 0.18,
-            insetY: frame.height * 0.18,
+          traceTriangle(ctx, x, y, width, height, {
+            insetX: width * 0.18,
+            insetY: height * 0.18,
           });
         },
       },
       {
         color: 'primary',
         draw(ctx, x, y, width, height) {
-          const frame = getCenteredSquareFrame(x, y, width, height);
-          traceTriangle(ctx, frame.x, frame.y, frame.width, frame.height, {
-            insetX: frame.width * 0.352,
-            insetY: frame.height * 0.352,
+          traceTriangle(ctx, x, y, width, height, {
+            insetX: width * 0.352,
+            insetY: height * 0.352,
           });
         },
       },
     ],
     secondaryFill: '#000000',
     draw(ctx, x, y, width, height) {
-      const frame = getCenteredSquareFrame(x, y, width, height);
-      traceTriangle(ctx, frame.x, frame.y, frame.width, frame.height);
+      traceTriangle(ctx, x, y, width, height);
     },
   },
 };


### PR DESCRIPTION
## Summary
- update double-layer shapes so their drawn geometry starts at the note onset and respects duration-based stretching
- adjust rounded shapes to reuse scaled frames without drifting from the left anchor
- add regression tests ensuring several double shapes stay aligned to the NOTE ON position

## Testing
- node test_shapes.js
- node test_note_alignment.js

------
https://chatgpt.com/codex/tasks/task_e_68faf05131148333a17fe46b5276c2d7