### PR TITLE
Fix double shape width handling

### DIFF
--- a/test_family_modifiers.js
+++ b/test_family_modifiers.js
@@ -19,4 +19,7 @@ assert.strictEqual(computeNoteWidth(notePlatillos, 10, 20), 26);
 const noteTambores = { start: 0, end: 1, shape: 'circle', family: 'Tambores' };
 assert.strictEqual(computeNoteWidth(noteTambores, 10, 20), 20);
 
+const sustainedDouble = { start: 0, end: 2, shape: 'circleDouble', family: 'Tambores' };
+assert.strictEqual(computeNoteWidth(sustainedDouble, 10, 20), 20);
+
 console.log('Pruebas de modificadores de familia completadas');

--- a/test_shape_extension_control.js
+++ b/test_shape_extension_control.js
@@ -18,4 +18,20 @@ setShapeExtension('circle', true);
 result = computeDynamicBounds(note, 2, canvasWidth, pixelsPerSecond, baseWidth, 'circle');
 assert.strictEqual(result.width, baseWidth + (finalWidth - baseWidth) / 2);
 
+const doubleNote = {
+  start: 1,
+  end: 3,
+  shape: 'circleDouble',
+  family: 'Percusión',
+};
+result = computeDynamicBounds(
+  doubleNote,
+  2,
+  canvasWidth,
+  pixelsPerSecond,
+  baseWidth,
+  'circleDouble',
+);
+assert.strictEqual(result.width, baseWidth);
+
 console.log('Pruebas de control de extensión de figuras completadas');

--- a/utils.js
+++ b/utils.js
@@ -1348,7 +1348,7 @@ function computeNoteWidth(note, noteHeight, pixelsPerSecond) {
     baseHeight,
   );
   if (!isExtensionEnabledForFamily(note.shape, note.family)) {
-    return durationWidth;
+    return isDoubleShape(note.shape) ? baseHeight : durationWidth;
   }
   return baseHeight;
 }
@@ -1366,8 +1366,9 @@ function computeDynamicBounds(
   const xStart = center + (note.start - currentSec) * pixelsPerSecond;
   const finalWidth = (note.end - note.start) * pixelsPerSecond;
   const effectiveShape = shape || note.shape;
+  const doubleShape = isDoubleShape(effectiveShape);
   if (!isExtensionEnabledForFamily(effectiveShape, note.family)) {
-    const width = finalWidth;
+    const width = doubleShape ? baseWidth : finalWidth;
     return { xStart, xEnd: xStart + width, width };
   }
   if (xStart > center) {


### PR DESCRIPTION
## Summary
- ensure double-note shapes keep their proportional footprint by using base dimensions when extensions are disabled
- update dynamic bound calculations so double shapes stay aligned to the note-on edge without stretching to the note-off
- extend automated checks to cover the new double-shape behaviour

## Testing
- node test_family_modifiers.js
- node test_shape_extension_control.js

------
https://chatgpt.com/codex/tasks/task_e_68fba16d4a78833393dbbd23769a2878