### PR TITLE
Add helper to toggle global shape extension

### DIFF
--- a/script.js
+++ b/script.js
@@ -37,6 +37,7 @@ const {
   computeDynamicBounds,
   computeDiamondBounds,
   setShapeExtension,
+  setShapeExtensionsEnabled,
   getShapeExtension,
   getShapeExtensions,
   setFamilyExtension,
@@ -3191,7 +3192,7 @@ if (typeof document !== 'undefined') {
         extensionToggle.indeterminate = false;
         if (!target) {
           clearAllFamilyExtensions();
-          STRETCHABLE_SHAPES.forEach((shape) => setShapeExtension(shape, enabled));
+          setShapeExtensionsEnabled(enabled);
         } else {
           const shape = getEffectiveFamilyShape(target);
           if (!shape || !isShapeExtendable(shape)) {
@@ -5131,6 +5132,7 @@ if (typeof module !== 'undefined') {
     computeDynamicBounds,
     computeDiamondBounds,
     setShapeExtension,
+    setShapeExtensionsEnabled,
     getShapeExtension,
     getShapeExtensions,
     setFamilyExtension,

--- a/test_shape_extension_control.js
+++ b/test_shape_extension_control.js
@@ -1,5 +1,10 @@
 const assert = require('assert');
-const { computeDynamicBounds, setShapeExtension } = require('./script');
+const {
+  computeDynamicBounds,
+  setShapeExtension,
+  setShapeExtensionsEnabled,
+  getShapeExtension,
+} = require('./script');
 
 const note = { start: 1, end: 3, shape: 'circle' };
 const canvasWidth = 200;
@@ -17,6 +22,12 @@ assert.strictEqual(result.width, finalWidth);
 setShapeExtension('circle', true);
 result = computeDynamicBounds(note, 2, canvasWidth, pixelsPerSecond, baseWidth, 'circle');
 assert.strictEqual(result.width, baseWidth + (finalWidth - baseWidth) / 2);
+
+setShapeExtensionsEnabled(false);
+assert.strictEqual(getShapeExtension('circle'), false);
+setShapeExtensionsEnabled(true);
+assert.strictEqual(getShapeExtension('circle'), true);
+assert.strictEqual(getShapeExtension('circleDouble'), false);
 
 const doubleNote = {
   start: 1,

--- a/utils.js
+++ b/utils.js
@@ -1138,6 +1138,18 @@ function setShapeExtension(shape, enabled) {
   }
 }
 
+function setShapeExtensionsEnabled(enabled) {
+  loadShapeExtensions();
+  const value = !!enabled;
+  Object.keys(shapeExtensions).forEach((shape) => {
+    shapeExtensions[shape] = isShapeExtendable(shape) ? value : false;
+  });
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('shapeExtensions', JSON.stringify(shapeExtensions));
+  }
+  return { ...shapeExtensions };
+}
+
 function getShapeExtensions() {
   loadShapeExtensions();
   return { ...shapeExtensions };
@@ -1566,6 +1578,7 @@ const utils = {
   getHeightScale,
   getHeightScaleConfig,
   setShapeExtension,
+  setShapeExtensionsEnabled,
   getShapeExtension,
   getShapeExtensions,
   setFamilyExtension,


### PR DESCRIPTION
## Summary
- add a utility function to enable or disable dynamic extensions for every stretchable shape at once
- update the family configuration panel to rely on the new helper
- extend the shape extension control test suite to cover the global toggle

## Testing
- node test_shape_extension_control.js

------
https://chatgpt.com/codex/tasks/task_e_68fd4ee402a88333bcacd1766f2c6e34