### PR TITLE
Add configurable stretch toggle for note shapes

### DIFF
--- a/test_config_export_import.js
+++ b/test_config_export_import.js
@@ -9,6 +9,8 @@ const {
   getBumpControl,
   getVisibleSeconds,
   getHeightScaleConfig,
+  getShapeStretch,
+  getFamilyStretch,
 } = require('./script.js');
 const { getOutlineSettings, resetOutlineSettings } = require('./utils.js');
 
@@ -41,6 +43,22 @@ const config = {
   bumpControl: { global: 1.2, families: { Metales: 1.1 } },
   visibleSeconds: 6,
   heightScale: { global: 2, families: {} },
+  shapeStretch: {
+    circle: true,
+    circleDouble: false,
+    square: true,
+    squareDouble: false,
+    roundedSquare: false,
+    roundedSquareDouble: false,
+    diamond: false,
+    diamondDouble: false,
+    fourPointStar: true,
+    fourPointStarDouble: false,
+    sixPointStar: false,
+    sixPointStarDouble: false,
+    triangle: true,
+    triangleDouble: false,
+  },
   shapeExtensions: {
     circle: true,
     circleDouble: false,
@@ -58,6 +76,7 @@ const config = {
     triangleDouble: false,
   },
   familyExtensions: { Metales: true },
+  familyStretch: { Metales: false },
   familyLineSettings: {},
   familyTravelSettings: {},
   outlineSettings: {
@@ -108,6 +127,9 @@ assert.strictEqual(getBumpControl(), 1.2);
 assert.strictEqual(getBumpControl('Metales'), 1.1);
 assert.strictEqual(getVisibleSeconds(), 6);
 assert.deepStrictEqual(getHeightScaleConfig(), { global: 2, families: {} });
+assert.strictEqual(getShapeStretch('roundedSquare'), false);
+assert.strictEqual(getShapeStretch('diamond'), false);
+assert.strictEqual(getFamilyStretch('Metales'), false);
 
 const exported = JSON.parse(exportConfiguration());
 assert.deepStrictEqual(exported, config);

--- a/test_shape_extension_control.js
+++ b/test_shape_extension_control.js
@@ -4,6 +4,9 @@ const {
   setShapeExtension,
   setShapeExtensionsEnabled,
   getShapeExtension,
+  setShapeStretch,
+  setShapeStretchEnabled,
+  getShapeStretch,
 } = require('./script');
 
 const note = { start: 1, end: 3, shape: 'circle' };
@@ -23,11 +26,22 @@ setShapeExtension('circle', true);
 result = computeDynamicBounds(note, 2, canvasWidth, pixelsPerSecond, baseWidth, 'circle');
 assert.strictEqual(result.width, baseWidth + (finalWidth - baseWidth) / 2);
 
+setShapeStretch('circle', false);
+result = computeDynamicBounds(note, 1.5, canvasWidth, pixelsPerSecond, baseWidth, 'circle');
+assert.strictEqual(result.width, baseWidth);
+
+setShapeStretch('circle', true);
+
 setShapeExtensionsEnabled(false);
 assert.strictEqual(getShapeExtension('circle'), false);
 setShapeExtensionsEnabled(true);
 assert.strictEqual(getShapeExtension('circle'), true);
 assert.strictEqual(getShapeExtension('circleDouble'), false);
+
+setShapeStretchEnabled(false);
+assert.strictEqual(getShapeStretch('circle'), false);
+setShapeStretchEnabled(true);
+assert.strictEqual(getShapeStretch('circle'), true);
 
 const doubleNote = {
   start: 1,


### PR DESCRIPTION
## Summary
- add a dedicated "Extensión" toggle that keeps figures proportional while notes remain active
- persist stretch enablement per shape and family, wiring the new setting into import/export and runtime utilities
- update automated coverage for the new stretch behavior and configuration round-tripping

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fd6243e7588333867a45685004bb10