### PR TITLE
Reorganize visual settings and animation customization layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -326,6 +326,7 @@ if (typeof document !== 'undefined') {
     const toggleFamilyPanelBtn = document.getElementById('toggle-family-panel');
     const familyPanel = document.getElementById('family-config-panel');
     const developerControls = document.getElementById('developer-controls');
+    let globalSettingsContainer = null;
     const assignmentModal = document.getElementById('assignment-modal');
     const modalInstrumentList = document.getElementById('modal-instrument-list');
     const modalFamilyZones = document.getElementById('modal-family-zones');
@@ -1448,6 +1449,11 @@ if (typeof document !== 'undefined') {
       ssItem.dataset.help =
         'Factor de supersampling inicial aplicado al canvas.';
       developerControls.appendChild(ssItem);
+
+      globalSettingsContainer = document.createElement('div');
+      globalSettingsContainer.id = 'global-visual-settings';
+      globalSettingsContainer.className = 'dev-control-section';
+      developerControls.appendChild(globalSettingsContainer);
     }
     // Inicializa los mensajes de ayuda flotantes
     initHelpMessages();
@@ -1522,10 +1528,16 @@ if (typeof document !== 'undefined') {
       const devControls = document.getElementById('developer-controls');
       familyPanel.innerHTML = '';
       if (devControls) familyPanel.appendChild(devControls);
+      if (globalSettingsContainer) {
+        globalSettingsContainer.innerHTML = '';
+      }
+
+      const customizationContainer = document.createElement('div');
+      customizationContainer.className = 'customization-sections';
 
       const scopeSelectorControl = document.createElement('div');
       scopeSelectorControl.className =
-        'family-config-item family-target-control scope-selector';
+        'dev-control family-target-control scope-selector';
       const scopeLabel = document.createElement('label');
       scopeLabel.textContent = 'Aplicar cambios a:';
       scopeLabel.setAttribute('for', 'config-scope-select');
@@ -1551,9 +1563,18 @@ if (typeof document !== 'undefined') {
       const familyScopeSection = document.createElement('div');
       familyScopeSection.className = 'config-scope-section scope-familia';
 
-      familyPanel.appendChild(scopeSelectorControl);
-      familyPanel.appendChild(instrumentScopeSection);
-      familyPanel.appendChild(familyScopeSection);
+      const appendToGlobalSettings = (element) => {
+        if (globalSettingsContainer) {
+          globalSettingsContainer.appendChild(element);
+        } else {
+          familyPanel.appendChild(element);
+        }
+      };
+
+      appendToGlobalSettings(scopeSelectorControl);
+      customizationContainer.appendChild(instrumentScopeSection);
+      customizationContainer.appendChild(familyScopeSection);
+      familyPanel.appendChild(customizationContainer);
 
       let updateHeightControl = () => {};
       let updateGlowControl = () => {};
@@ -1848,7 +1869,7 @@ if (typeof document !== 'undefined') {
       };
 
       const bgItem = document.createElement('div');
-      bgItem.className = 'family-config-item';
+      bgItem.className = 'dev-control';
       const bgLabel = document.createElement('label');
       bgLabel.textContent = 'Color del canvas';
       const bgInput = document.createElement('input');
@@ -1861,10 +1882,10 @@ if (typeof document !== 'undefined') {
       });
       bgItem.appendChild(bgLabel);
       bgItem.appendChild(bgInput);
-      familyPanel.appendChild(bgItem);
+      appendToGlobalSettings(bgItem);
 
       const bgImageItem = document.createElement('div');
-      bgImageItem.className = 'family-config-item family-config-group';
+      bgImageItem.className = 'dev-control family-config-group';
       const bgImageLabel = document.createElement('label');
       bgImageLabel.textContent = 'Imagen de fondo:';
       const bgImageInfo = document.createElement('span');
@@ -1956,10 +1977,10 @@ if (typeof document !== 'undefined') {
       bgImageItem.appendChild(bgImageButtons);
       bgImageItem.appendChild(bgImageInfo);
       bgImageItem.appendChild(bgImageInput);
-      familyPanel.appendChild(bgImageItem);
+      appendToGlobalSettings(bgImageItem);
 
       const bgOpacityItem = document.createElement('div');
-      bgOpacityItem.className = 'family-config-item family-config-group';
+      bgOpacityItem.className = 'dev-control family-config-group';
       const bgOpacityLabel = document.createElement('label');
       bgOpacityLabel.textContent = 'Opacidad imagen (%):';
       const bgOpacityInput = document.createElement('input');
@@ -1991,7 +2012,7 @@ if (typeof document !== 'undefined') {
       bgOpacityItem.appendChild(bgOpacityLabel);
       bgOpacityItem.appendChild(bgOpacityInput);
       bgOpacityItem.appendChild(bgOpacityHint);
-      familyPanel.appendChild(bgOpacityItem);
+      appendToGlobalSettings(bgOpacityItem);
 
       updateBackgroundImageControl();
       updateBackgroundOpacityControl();

--- a/styles.css
+++ b/styles.css
@@ -128,6 +128,16 @@ input:hover {
   grid-column: 1 / -1;
 }
 
+.dev-control-section {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  border-top: 1px solid #333;
+  padding-top: 12px;
+  margin-top: 4px;
+}
+
 .dev-control {
   display: grid;
   gap: 8px;
@@ -355,13 +365,22 @@ input:hover {
 }
 
 .scope-selector {
-  margin-bottom: 8px;
+  margin: 0;
+}
+
+.customization-sections {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+  align-content: start;
 }
 
 .config-scope-section {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 12px;
+  align-content: start;
 }
 
 .config-scope-section.hidden {


### PR DESCRIPTION
## Summary
- move the configuration scope selector and canvas background controls into the developer settings block
- reorganize the customization sections so animation options stay grouped at the bottom with an improved grid layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fdf52940708333a827a55aec156362