### PR TITLE
Improve bump/glow effects and persist instrument scope

### DIFF
--- a/test_bump_control.js
+++ b/test_bump_control.js
@@ -7,11 +7,13 @@ function approx(a, b, eps = 1e-6) {
 
 const base = 10;
 setBumpControl(2);
-approx(computeBumpHeight(base, 0, 0, 1), 20);
-approx(computeBumpHeight(base, 1, 0, 1), 15);
+approx(computeBumpHeight(base, 0, 0, 1), base);
+approx(computeBumpHeight(base, 0.7, 0, 1), 20);
+approx(computeBumpHeight(base, 1, 0, 1), 15.9171597633);
 approx(computeBumpHeight(base, 2, 0, 1), base);
 setBumpControl(1.5, 'Metales');
-approx(computeBumpHeight(base, 0, 0, 1, 0.5, 'Metales'), 17.5);
-approx(computeBumpHeight(base, 1, 0, 1, 0.5, 'Metales'), 12.5);
+approx(computeBumpHeight(base, 0, 0, 1, 0.5, 'Metales'), base);
+approx(computeBumpHeight(base, 0.525, 0, 1, 0.5, 'Metales'), 17.5);
+approx(computeBumpHeight(base, 1, 0, 1, 0.5, 'Metales'), 11.9723865878);
 
 console.log('Pruebas de control de bump completadas');

--- a/test_config_export_import.js
+++ b/test_config_export_import.js
@@ -36,6 +36,9 @@ const config = {
   familyCustomizations: {
     Metales: { color: '#123456', shape: 'diamond', secondaryColor: '#222222' },
   },
+  instrumentCustomizations: {
+    Flauta: { color: '#abcdef', shape: 'triangle' },
+  },
   enabledInstruments: { Flauta: true },
   velocityBase: 80,
   opacityScale: { edge: 0.1, mid: 0.8 },
@@ -115,12 +118,12 @@ assert.strictEqual(familyOutline.opacity, 0.5);
 assert.strictEqual(familyOutline.enabled, true);
 
 assert.strictEqual(tracks[0].family, 'Metales');
-assert.strictEqual(tracks[0].shape, 'diamond');
-assert.strictEqual(tracks[0].color, '#123456');
+assert.strictEqual(tracks[0].shape, 'triangle');
+assert.strictEqual(tracks[0].color, '#abcdef');
 assert.strictEqual(tracks[0].secondaryColor, '#222222');
 assert.strictEqual(notes[0].family, 'Metales');
-assert.strictEqual(notes[0].shape, 'diamond');
-assert.strictEqual(notes[0].color, '#123456');
+assert.strictEqual(notes[0].shape, 'triangle');
+assert.strictEqual(notes[0].color, '#abcdef');
 assert.strictEqual(notes[0].secondaryColor, '#222222');
 
 assert.strictEqual(getVelocityBase(), 80);

--- a/test_glow_control.js
+++ b/test_glow_control.js
@@ -14,19 +14,32 @@ const ctx = {
   shadowBlur: 0,
   shadowColor: null,
   fillStyle: null,
+  ellipses: [],
+  gradients: [],
   save() {},
   restore() {},
   beginPath() {},
-  rect(x, y, w, h) {
-    this.w = w;
-    this.h = h;
+  ellipse(cx, cy, rx, ry) {
+    this.ellipses.push({ cx, cy, rx, ry });
   },
+  rect() {},
   fill() {},
+  createRadialGradient() {
+    const stops = [];
+    this.gradients.push(stops);
+    return {
+      addColorStop(pos, color) {
+        stops.push({ pos, color });
+      },
+    };
+  },
 };
 
 applyGlowEffect(ctx, 'square', 0, 0, 10, 10, 0.5, 'Metales');
 assert(ctx.shadowBlur > 20, 'blur no escalado');
-assert.strictEqual(ctx.w, 10, 'el ancho no debe cambiar');
-assert(ctx.h > 10, 'la altura debe escalarse');
+assert(ctx.ellipses.length > 0, 'el glow debe generar un halo amplio');
+const haloRadius = ctx.ellipses.reduce((max, e) => Math.max(max, e.rx, e.ry), 0);
+assert(haloRadius > 10, 'el halo debe superar el tamaño de la figura');
+assert(ctx.gradients.length > 0, 'el glow debe utilizar gradientes');
 
 console.log('Pruebas de control de glow completadas');

--- a/test_visual_effects.js
+++ b/test_visual_effects.js
@@ -24,10 +24,16 @@ setOpacityScale(0, 0.5);
 // Pruebas para computeBumpHeight
 const base = 10;
 approx(computeBumpHeight(base, -0.1, 0, 1), base); // Antes de la nota
-approx(computeBumpHeight(base, 0, 0, 1), 16); // En el NOTE ON con bump 120%
-approx(computeBumpHeight(base, 0.5, 0, 1), 13.5); // Mitad del intervalo extendido
+approx(computeBumpHeight(base, 0, 0, 1), base); // Inicio sin incremento instantáneo
+approx(
+  computeBumpHeight(base, 0.12, 0, 1),
+  13.8134110787,
+  1e-6,
+); // Aumento progresivo rápido
+approx(computeBumpHeight(base, 0.42, 0, 1), 16); // Pico del bump (120%)
+approx(computeBumpHeight(base, 0.9, 0, 1), 10.888, 1e-3); // Decaimiento cercano al final
 approx(computeBumpHeight(base, 1.2, 0, 1), base); // Regreso tras la extensión del bump
-approx(computeBumpHeight(base, 0, 0, 1, 0.8), 19.6); // Bump incrementado
+approx(computeBumpHeight(base, 0.42, 0, 1, 0.8), 19.6); // Bump incrementado
 
 // Pruebas para computeGlowAlpha
 approx(computeGlowAlpha(0, 0), 1); // Inicio del brillo
@@ -40,23 +46,35 @@ const glowCtx = {
   shadowBlur: 0,
   shadowColor: null,
   fillStyle: null,
+  ellipses: [],
+  gradients: [],
   save() {},
   restore() {},
   beginPath() {},
-  rect(x, y, w, h) {
-    this.lastWidth = w;
-    this.lastHeight = h;
+  ellipse(cx, cy, rx, ry) {
+    this.ellipses.push({ cx, cy, rx, ry });
   },
-  fillCalled: false,
+  rect() {},
+  fillCalled: 0,
   fill() {
-    this.fillCalled = true;
+    this.fillCalled += 1;
+  },
+  createRadialGradient() {
+    const stops = [];
+    this.gradients.push(stops);
+    return {
+      addColorStop(pos, color) {
+        stops.push({ pos, color });
+      },
+    };
   },
 };
 applyGlowEffect(glowCtx, 'square', 0, 0, 10, 10, 0.5);
-assert.strictEqual(glowCtx.lastWidth, 10, 'el glow no debe alterar el ancho');
-assert.strictEqual(glowCtx.lastHeight, 15, 'el glow debe escalar solo la altura');
+assert(glowCtx.ellipses.length > 0, 'el glow debe dibujar un halo elíptico');
+const largestGlow = glowCtx.ellipses.reduce((max, e) => Math.max(max, e.rx, e.ry), 0);
+assert(largestGlow > 10, 'el resplandor debe extenderse más allá de la figura');
 assert(glowCtx.shadowBlur > 0, 'shadowBlur no aplicado');
-assert.strictEqual(glowCtx.fillStyle, '#ffffff');
-assert(glowCtx.fillCalled, 'fill no llamado en glow');
+assert(glowCtx.gradients.length > 0, 'el glow debe utilizar un gradiente suave');
+assert(glowCtx.fillCalled > 0, 'fill no llamado en glow');
 
 console.log('Pruebas de efectos visuales completadas');


### PR DESCRIPTION
## Summary
- reshape the bump animation to ease in/out of the size boost and render a softer, diffuse glow
- persist per-instrument customization scope via sanitized storage, export/import, and runtime application
- update automated tests to reflect the refined visual behaviour and new configuration fields

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fdf83c02088333a573289693fa4ba3