### PR TITLE
Add configurable FPS mode selector with default 90 FPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,30 @@
       title="Pantalla completa"
       data-help="Expande el canvas a pantalla completa con supersampling."
     >Pantalla completa</button>
+    <div
+      id="fps-control-group"
+      class="fps-control"
+      data-help="Selecciona si la animación sigue la frecuencia de actualización de tu pantalla o usa un valor fijo."
+    >
+      <label for="fps-mode">Modo de FPS</label>
+      <select
+        id="fps-mode"
+        title="Define cómo se sincroniza la animación con la pantalla"
+      >
+        <option value="auto">Automático (según pantalla)</option>
+        <option value="fixed">Fijo</option>
+      </select>
+      <label for="fps-value">FPS fijos</label>
+      <input
+        type="number"
+        id="fps-value"
+        min="30"
+        max="240"
+        step="1"
+        value="90"
+        title="Especifica los fotogramas por segundo cuando se usa el modo fijo"
+      />
+    </div>
   </nav>
 
   <canvas

--- a/styles.css
+++ b/styles.css
@@ -44,6 +44,32 @@ body {
   min-height: 38px;
 }
 
+#fps-control-group {
+  display: grid;
+  gap: 6px;
+  padding: 8px;
+  border: 1px solid #333;
+  border-radius: 6px;
+  background: #181818;
+  align-content: start;
+  grid-column: span 2;
+}
+
+#fps-control-group label {
+  font-weight: 600;
+}
+
+#fps-control-group select,
+#fps-control-group input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+#fps-value:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* Layout específico para el menú inferior para mantener
    un formato organizado y simétrico */
 #bottom-menu {

--- a/test_fps_controls_removed.js
+++ b/test_fps_controls_removed.js
@@ -1,14 +1,79 @@
 const assert = require('assert');
 const fs = require('fs');
-const exportsMap = require('./script');
-
-assert.strictEqual('setFPSMode' in exportsMap, false);
-assert.strictEqual('getFPSMode' in exportsMap, false);
-assert.strictEqual('setFixedFPS' in exportsMap, false);
-assert.strictEqual('setFrameWindow' in exportsMap, false);
-assert.strictEqual('startFixedFPSLoop' in exportsMap, false);
+const {
+  setFPSMode,
+  getFPSMode,
+  setFixedFPS,
+  getFixedFPS,
+  startFixedFPSLoop,
+} = require('./script.js');
 
 const html = fs.readFileSync('index.html', 'utf8');
-assert(!html.includes('toggle-fps'));
+assert(html.includes('id="fps-mode"'));
+assert(html.includes('id="fps-value"'));
 
-console.log('Controles manuales de FPS eliminados correctamente');
+assert.strictEqual(getFPSMode(), 'fixed');
+setFPSMode('auto');
+assert.strictEqual(getFPSMode(), 'auto');
+setFPSMode('invalid');
+assert.strictEqual(getFPSMode(), 'fixed');
+
+assert.strictEqual(getFixedFPS(), 90);
+setFixedFPS(500);
+assert.strictEqual(getFixedFPS(), 240);
+setFixedFPS(10);
+assert.strictEqual(getFixedFPS(), 30);
+
+const originalRAF = global.requestAnimationFrame;
+const originalCancel = global.cancelAnimationFrame;
+const originalPerformance = global.performance;
+let scheduled = [];
+const canceled = [];
+let currentNow = 0;
+
+global.performance = { now: () => currentNow };
+global.requestAnimationFrame = (fn) => {
+  scheduled.push(fn);
+  return scheduled.length;
+};
+global.cancelAnimationFrame = (id) => {
+  canceled.push(id);
+};
+
+const deltas = [];
+const stop = startFixedFPSLoop((dt) => {
+  deltas.push(dt);
+}, 50);
+
+function runFrame(time) {
+  currentNow = time;
+  const cb = scheduled.shift();
+  assert(cb, 'No hay frame programado');
+  cb(time);
+}
+
+assert.strictEqual(scheduled.length, 1);
+runFrame(0);
+assert.deepStrictEqual(deltas, [0]);
+assert.strictEqual(scheduled.length, 1);
+runFrame(10);
+assert.deepStrictEqual(deltas, [0]);
+assert.strictEqual(scheduled.length, 1);
+runFrame(30);
+assert.deepStrictEqual(deltas, [0, 20]);
+assert.strictEqual(scheduled.length, 1);
+runFrame(50);
+assert.deepStrictEqual(deltas, [0, 20, 20]);
+
+stop();
+assert(canceled.length >= 1);
+
+if (originalPerformance) {
+  global.performance = originalPerformance;
+} else {
+  delete global.performance;
+}
+global.requestAnimationFrame = originalRAF;
+global.cancelAnimationFrame = originalCancel;
+
+console.log('Controles de FPS disponibles y funcionales');

--- a/test_ui_integration.js
+++ b/test_ui_integration.js
@@ -13,6 +13,11 @@ const dom = new JSDOM(`<!DOCTYPE html><html><body>
 <button id="aspect-16-9"></button>
 <button id="aspect-9-16"></button>
 <button id="full-screen"></button>
+<select id="fps-mode">
+  <option value="auto">Auto</option>
+  <option value="fixed">Fijo</option>
+</select>
+<input id="fps-value" />
 </body></html>`);
 
 global.document = dom.window.document;
@@ -23,6 +28,8 @@ let stopCalls = 0;
 let forwardCalls = 0;
 let backwardCalls = 0;
 let refreshCalls = 0;
+const modeChanges = [];
+const fpsChanges = [];
 
 initializeUI({
   isPlaying: () => playing,
@@ -47,6 +54,16 @@ initializeUI({
   onAspect169: () => {},
   onAspect916: () => {},
   onFullScreen: () => {},
+  fpsMode: 'fixed',
+  fpsValue: 90,
+  onFPSModeChange: (mode) => {
+    modeChanges.push(mode);
+    return mode;
+  },
+  onFPSValueChange: (value) => {
+    fpsChanges.push(value);
+    return value;
+  },
 });
 
 document.getElementById('play-stop').click();
@@ -62,5 +79,19 @@ assert.strictEqual(stopCalls, 1);
 assert.strictEqual(forwardCalls, 2);
 assert.strictEqual(backwardCalls, 2);
 assert.strictEqual(refreshCalls, 1);
+
+const modeSelect = document.getElementById('fps-mode');
+const fpsInput = document.getElementById('fps-value');
+modeSelect.value = 'auto';
+modeSelect.dispatchEvent(new dom.window.Event('change'));
+assert.strictEqual(modeSelect.disabled, false);
+assert.strictEqual(fpsInput.disabled, true);
+modeSelect.value = 'fixed';
+modeSelect.dispatchEvent(new dom.window.Event('change'));
+fpsInput.value = '120';
+fpsInput.dispatchEvent(new dom.window.Event('change'));
+
+assert.deepStrictEqual(modeChanges, ['auto', 'fixed']);
+assert.strictEqual(fpsChanges[fpsChanges.length - 1], 120);
 
 console.log('Pruebas de integración de UI completadas');

--- a/ui.js
+++ b/ui.js
@@ -12,6 +12,10 @@ function initializeUI({
   onAspect169,
   onAspect916,
   onFullScreen,
+  fpsMode,
+  fpsValue,
+  onFPSModeChange,
+  onFPSValueChange,
 }) {
   const playBtn = document.getElementById('play-stop');
   const forwardBtn = document.getElementById('seek-forward');
@@ -23,6 +27,56 @@ function initializeUI({
   const aspect169Btn = document.getElementById('aspect-16-9');
   const aspect916Btn = document.getElementById('aspect-9-16');
   const fullScreenBtn = document.getElementById('full-screen');
+  const fpsModeSelect = document.getElementById('fps-mode');
+  const fpsValueInput = document.getElementById('fps-value');
+
+  const updateFPSAvailability = () => {
+    if (fpsValueInput) {
+      const fixedSelected = fpsModeSelect && fpsModeSelect.value === 'fixed';
+      fpsValueInput.disabled = !fixedSelected;
+    }
+  };
+
+  if (fpsModeSelect) {
+    if (typeof fpsMode === 'string') {
+      const option = fpsModeSelect.querySelector(`option[value="${fpsMode}"]`);
+      if (option) {
+        fpsModeSelect.value = fpsMode;
+      }
+    }
+    updateFPSAvailability();
+    fpsModeSelect.addEventListener('change', () => {
+      const selected = fpsModeSelect.value === 'fixed' ? 'fixed' : 'auto';
+      let nextMode = selected;
+      if (typeof onFPSModeChange === 'function') {
+        const result = onFPSModeChange(selected);
+        if (typeof result === 'string') {
+          nextMode = result;
+        }
+      }
+      const option = fpsModeSelect.querySelector(`option[value="${nextMode}"]`);
+      if (option) {
+        fpsModeSelect.value = nextMode;
+      }
+      updateFPSAvailability();
+    });
+  }
+
+  if (fpsValueInput) {
+    if (typeof fpsValue === 'number' && Number.isFinite(fpsValue)) {
+      fpsValueInput.value = String(fpsValue);
+    }
+    updateFPSAvailability();
+    fpsValueInput.addEventListener('change', () => {
+      if (typeof onFPSValueChange === 'function') {
+        const parsed = Number(fpsValueInput.value);
+        const result = onFPSValueChange(parsed);
+        if (typeof result === 'number' && Number.isFinite(result)) {
+          fpsValueInput.value = String(result);
+        }
+      }
+    });
+  }
 
   playBtn.addEventListener('click', () => {
     if (isPlaying()) {
@@ -58,6 +112,20 @@ function initializeUI({
     aspect169Btn,
     aspect916Btn,
     fullScreenBtn,
+    fpsModeSelect,
+    fpsValueInput,
+    refreshFPSControls: (mode, value) => {
+      if (fpsModeSelect && typeof mode === 'string') {
+        const option = fpsModeSelect.querySelector(`option[value="${mode}"]`);
+        if (option) {
+          fpsModeSelect.value = mode;
+        }
+      }
+      if (fpsValueInput && typeof value === 'number' && Number.isFinite(value)) {
+        fpsValueInput.value = String(value);
+      }
+      updateFPSAvailability();
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- add a top menu control to switch between automatic FPS and a fixed value, defaulting to 90 FPS
- persist FPS preferences and restart the animation loop using either auto or fixed rate scheduling
- introduce a fixed FPS loop helper and update tests to cover the new controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fe00842d748333a83498dac5e44cd0