### PR TITLE
Reorganizar la interfaz con paneles simétricos

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,199 +12,224 @@
   />
 </head>
 <body>
-  <h1 id="app-title">Visualizador MIDI - Jaime Jaramillo Arias</h1>
-  <nav id="top-menu">
-    <button
-      id="load-midi"
-      title="Cargar archivo MIDI"
-      data-help="Selecciona un archivo MIDI local para visualizar sus notas."
-    >Cargar MIDI</button>
-    <button
-      id="load-wav"
-      title="Cargar archivo WAV"
-      data-help="Carga un archivo WAV y sincroniza el audio con la animación."
-    >Cargar WAV</button>
-    <button
-      id="play-stop"
-      title="Reproducir o detener"
-      data-help="Inicia o detiene la reproducción de la animación y el audio cargado."
-    >Play/Stop</button>
-    <button
-      id="seek-forward"
-      title="Adelantar 3 segundos"
-      data-help="Avanza la reproducción tres segundos."
-    >Adelantar</button>
-    <button
-      id="seek-backward"
-      title="Atrasar 3 segundos"
-      data-help="Retrocede la reproducción tres segundos."
-    >Atrasar</button>
-    <button
-      id="seek-backward-arrow"
-      class="icon-button"
-      title="Retroceder reproducción"
-      aria-label="Retroceder"
-      data-help="Retrocede rápidamente utilizando un control en forma de flecha."
-    >&#9664;</button>
-    <button
-      id="seek-forward-arrow"
-      class="icon-button"
-      title="Avanzar reproducción"
-      aria-label="Avanzar"
-      data-help="Avanza rápidamente utilizando un control en forma de flecha."
-    >&#9654;</button>
-    <button
-      id="restart"
-      title="Reiniciar"
-      data-help="Regresa la reproducción al inicio."
-    >Inicio</button>
-    <button
-      id="refresh-animation"
-      title="Refrescar animación"
-      data-help="Reinicia el motor de animación sin perder el audio, el MIDI ni las preferencias."
-    >Refrescar animación</button>
-    <button
-      id="aspect-16-9"
-      title="Cambiar a 16:9"
-      data-help="Establece el canvas en formato horizontal 16:9."
-    >16:9</button>
-    <button
-      id="aspect-9-16"
-      title="Cambiar a 9:16"
-      data-help="Establece el canvas en formato vertical 9:16."
-    >9:16</button>
-    <button
-      id="full-screen"
-      title="Pantalla completa"
-      data-help="Expande el canvas a pantalla completa con supersampling."
-    >Pantalla completa</button>
-    <div
-      id="fps-control-group"
-      class="fps-control"
-      data-help="Selecciona si la animación sigue la frecuencia de actualización de tu pantalla o usa un valor fijo."
-    >
-      <label for="fps-mode">Modo de FPS</label>
-      <select
-        id="fps-mode"
-        title="Define cómo se sincroniza la animación con la pantalla"
-      >
-        <option value="auto">Automático (según pantalla)</option>
-        <option value="fixed">Fijo</option>
-      </select>
-      <label for="fps-value">FPS fijos</label>
-      <input
-        type="number"
-        id="fps-value"
-        min="30"
-        max="240"
-        step="1"
-        value="90"
-        title="Especifica los fotogramas por segundo cuando se usa el modo fijo"
-      />
-    </div>
-  </nav>
-
-  <canvas
-    id="visualizer"
-    width="1280"
-    height="720"
-    title="Área de visualización"
-    data-help="Muestra la animación de las notas del archivo MIDI."
-  ></canvas>
-
-  <input
-    type="file"
-    id="midi-file-input"
-    accept=".mid,.midi"
-    style="display: none"
-  />
-
-  <input
-    type="file"
-    id="wav-file-input"
-    accept=".wav,audio/wav"
-    style="display: none"
-  />
-
-  <nav id="bottom-menu">
-    <button
-      id="toggle-family-panel"
-      title="Panel de familias"
-      data-help="Despliega el panel para personalizar color y figura de cada familia."
-    >▲</button>
-    <button
-      id="tap-tempo-mode"
-      title="Modo tap tempo"
-      data-help="Accede a las herramientas de tap tempo para definir el mapa de tempo a partir del audio."
-    >Modo tap tempo</button>
-  </nav>
-
-  <div id="family-config-panel" class="active">
-    <div id="developer-controls"></div>
-  </div>
-
-  <div id="tap-tempo-panel" class="hidden">
-    <div id="tap-tempo-controls">
-      <button
-        id="start-tap-tempo"
-        title="Iniciar captura de tap tempo"
-        data-help="Reproduce el audio desde el inicio y registra tus pulsos con cualquier tecla."
-      >Iniciar tap tempo</button>
-      <button
-        id="stop-tap-tempo"
-        title="Detener o reiniciar el proceso de tap tempo"
-        data-help="Detiene la captura en curso o restaura el mapa de tempo original sin necesidad de volver a cargar el audio."
-      >Reiniciar proceso tap tempo</button>
-      <p id="tap-tempo-status">
-        Carga un archivo WAV y utiliza el tap tempo para crear un mapa de tempo personalizado. Usa Alt+clic para añadir marcadores, muévelos desde el punto superior con las flechas y elimínalos desde el punto inferior.
-      </p>
-    </div>
-    <div id="tap-tempo-editor" class="hidden">
-      <div class="tap-tempo-toolbar">
-        <label>
-          Zoom
-          <input
-            type="range"
-            id="tap-zoom"
-            min="0"
-            max="100"
-            value="0"
-            title="Ajusta la cantidad de audio visible en la forma de onda"
-          />
-        </label>
-        <label>
-          Posición
-          <input
-            type="range"
-            id="tap-position"
-            min="0"
-            max="100"
-            value="0"
-            title="Desplaza la ventana visible de la forma de onda"
-          />
-        </label>
-        <button
-          id="tap-marker-add"
-          type="button"
-          title="Agregar un nuevo marcador (también disponible con Alt+clic)"
-        >Agregar marcador</button>
-        <button
-          id="tap-marker-delete"
-          type="button"
-          title="Eliminar el marcador seleccionado"
-        >Eliminar marcador</button>
+  <div id="app-container">
+    <h1 id="app-title">Visualizador MIDI - Jaime Jaramillo Arias</h1>
+    <nav id="top-menu">
+      <div class="control-block" id="file-controls">
+        <h2 class="control-block-title">Archivos y reproducción</h2>
+        <div class="control-grid grid-2">
+          <button
+            id="load-midi"
+            title="Cargar archivo MIDI"
+            data-help="Selecciona un archivo MIDI local para visualizar sus notas."
+          >Cargar MIDI</button>
+          <button
+            id="load-wav"
+            title="Cargar archivo WAV"
+            data-help="Carga un archivo WAV y sincroniza el audio con la animación."
+          >Cargar WAV</button>
+          <button
+            id="play-stop"
+            title="Reproducir o detener"
+            data-help="Inicia o detiene la reproducción de la animación y el audio cargado."
+          >Play/Stop</button>
+          <button
+            id="refresh-animation"
+            title="Refrescar animación"
+            data-help="Reinicia el motor de animación sin perder el audio, el MIDI ni las preferencias."
+          >Refrescar animación</button>
+        </div>
       </div>
-      <canvas
-        id="tap-waveform"
-        width="1200"
-        height="360"
-        title="Forma de onda del audio con marcadores de tempo"
-      ></canvas>
-      <p class="tap-tempo-hint">
-        Arrastra cada marcador desde el punto superior con las flechas dobles para reubicarlo. Usa Alt+clic en la forma de onda para añadir nuevos marcadores y haz clic en el punto inferior con el signo menos para eliminarlo.
-      </p>
+      <div class="control-block" id="navigation-controls">
+        <h2 class="control-block-title">Navegación</h2>
+        <div class="control-grid grid-3">
+          <button
+            id="seek-backward"
+            title="Atrasar 3 segundos"
+            data-help="Retrocede la reproducción tres segundos."
+          >Atrasar</button>
+          <button
+            id="restart"
+            title="Reiniciar"
+            data-help="Regresa la reproducción al inicio."
+          >Inicio</button>
+          <button
+            id="seek-forward"
+            title="Adelantar 3 segundos"
+            data-help="Avanza la reproducción tres segundos."
+          >Adelantar</button>
+          <button
+            id="seek-backward-arrow"
+            class="icon-button"
+            title="Retroceder reproducción"
+            aria-label="Retroceder"
+            data-help="Retrocede rápidamente utilizando un control en forma de flecha."
+          >&#9664;</button>
+          <button
+            id="tap-tempo-mode"
+            data-action="tap-tempo"
+            title="Modo tap tempo"
+            data-help="Accede a las herramientas de tap tempo para definir el mapa de tempo a partir del audio."
+          >Modo tap tempo</button>
+          <button
+            id="seek-forward-arrow"
+            class="icon-button"
+            title="Avanzar reproducción"
+            aria-label="Avanzar"
+            data-help="Avanza rápidamente utilizando un control en forma de flecha."
+          >&#9654;</button>
+        </div>
+      </div>
+      <div class="control-block" id="view-controls">
+        <h2 class="control-block-title">Visualización</h2>
+        <div class="control-grid grid-3">
+          <button
+            id="aspect-16-9"
+            title="Cambiar a 16:9"
+            data-help="Establece el canvas en formato horizontal 16:9."
+          >16:9</button>
+          <button
+            id="full-screen"
+            title="Pantalla completa"
+            data-help="Expande el canvas a pantalla completa con supersampling."
+          >Pantalla completa</button>
+          <button
+            id="aspect-9-16"
+            title="Cambiar a 9:16"
+            data-help="Establece el canvas en formato vertical 9:16."
+          >9:16</button>
+        </div>
+        <div
+          id="fps-control-group"
+          class="fps-control"
+          data-help="Selecciona si la animación sigue la frecuencia de actualización de tu pantalla o usa un valor fijo."
+        >
+          <label for="fps-mode">Modo de FPS</label>
+          <select
+            id="fps-mode"
+            title="Define cómo se sincroniza la animación con la pantalla"
+          >
+            <option value="auto">Automático (según pantalla)</option>
+            <option value="fixed">Fijo</option>
+          </select>
+          <label for="fps-value">FPS fijos</label>
+          <input
+            type="number"
+            id="fps-value"
+            min="30"
+            max="240"
+            step="1"
+            value="90"
+            title="Especifica los fotogramas por segundo cuando se usa el modo fijo"
+          />
+        </div>
+      </div>
+    </nav>
+
+    <canvas
+      id="visualizer"
+      width="1280"
+      height="720"
+      title="Área de visualización"
+      data-help="Muestra la animación de las notas del archivo MIDI."
+    ></canvas>
+
+    <input
+      type="file"
+      id="midi-file-input"
+      accept=".mid,.midi"
+      style="display: none"
+    />
+
+    <input
+      type="file"
+      id="wav-file-input"
+      accept=".wav,audio/wav"
+      style="display: none"
+    />
+
+    <nav id="bottom-menu">
+      <button
+        id="toggle-family-panel"
+        title="Panel de familias"
+        data-help="Despliega el panel para personalizar color y figura de cada familia."
+      >▲</button>
+      <button
+        id="tap-tempo-mode-secondary"
+        data-action="tap-tempo"
+        title="Modo tap tempo"
+        data-help="Accede a las herramientas de tap tempo para definir el mapa de tempo a partir del audio."
+      >Modo tap tempo</button>
+    </nav>
+
+    <div id="family-config-panel" class="active">
+      <div id="developer-controls"></div>
     </div>
-    <div id="tap-tooltip" class="tooltip hidden"></div>
+
+    <div id="tap-tempo-panel" class="hidden">
+      <div id="tap-tempo-controls">
+        <button
+          id="start-tap-tempo"
+          title="Iniciar captura de tap tempo"
+          data-help="Reproduce el audio desde el inicio y registra tus pulsos con cualquier tecla."
+        >Iniciar tap tempo</button>
+        <button
+          id="stop-tap-tempo"
+          title="Detener o reiniciar el proceso de tap tempo"
+          data-help="Detiene la captura en curso o restaura el mapa de tempo original sin necesidad de volver a cargar el audio."
+        >Reiniciar proceso tap tempo</button>
+        <p id="tap-tempo-status">
+          Carga un archivo WAV y utiliza el tap tempo para crear un mapa de tempo personalizado. Usa Alt+clic para añadir marcadores,
+          muévelos desde el punto superior con las flechas y elimínalos desde el punto inferior.
+        </p>
+      </div>
+      <div id="tap-tempo-editor" class="hidden">
+        <div class="tap-tempo-toolbar">
+          <label>
+            Zoom
+            <input
+              type="range"
+              id="tap-zoom"
+              min="0"
+              max="100"
+              value="0"
+              title="Ajusta la cantidad de audio visible en la forma de onda"
+            />
+          </label>
+          <label>
+            Posición
+            <input
+              type="range"
+              id="tap-position"
+              min="0"
+              max="100"
+              value="0"
+              title="Desplaza la ventana visible de la forma de onda"
+            />
+          </label>
+          <button
+            id="tap-marker-add"
+            type="button"
+            title="Agregar un nuevo marcador (también disponible con Alt+clic)"
+          >Agregar marcador</button>
+          <button
+            id="tap-marker-delete"
+            type="button"
+            title="Eliminar el marcador seleccionado"
+          >Eliminar marcador</button>
+        </div>
+        <canvas
+          id="tap-waveform"
+          width="1200"
+          height="360"
+          title="Forma de onda del audio con marcadores de tempo"
+        ></canvas>
+        <p class="tap-tempo-hint">
+          Arrastra cada marcador desde el punto superior con las flechas dobles para reubicarlo. Usa Alt+clic en la forma de onda para añadir nuevos marcadores y haz clic en el punto inferior con el signo menos para eliminarlo.
+        </p>
+      </div>
+      <div id="tap-tooltip" class="tooltip hidden"></div>
+    </div>
   </div>
 
   <div id="assignment-modal" class="hidden">

--- a/script.js
+++ b/script.js
@@ -397,7 +397,9 @@ if (typeof document !== 'undefined') {
     const modalInstrumentList = document.getElementById('modal-instrument-list');
     const modalFamilyZones = document.getElementById('modal-family-zones');
     const applyAssignmentsBtn = document.getElementById('apply-assignments');
-    const tapTempoBtn = document.getElementById('tap-tempo-mode');
+    const tapTempoButtons = Array.from(
+      document.querySelectorAll('[data-action="tap-tempo"]')
+    );
     const tapTempoPanel = document.getElementById('tap-tempo-panel');
     const startTapTempoBtn = document.getElementById('start-tap-tempo');
     const stopTapTempoBtn = document.getElementById('stop-tap-tempo');
@@ -524,7 +526,7 @@ if (typeof document !== 'undefined') {
       if (!tapTempoModeActive) return;
       tapTempoModeActive = false;
       if (tapTempoPanel) tapTempoPanel.classList.add('hidden');
-      if (tapTempoBtn) tapTempoBtn.classList.remove('active');
+      tapTempoButtons.forEach((btn) => btn.classList.remove('active'));
       hideTooltip();
       hoveredHandleKey = null;
       updateCursor();
@@ -534,7 +536,7 @@ if (typeof document !== 'undefined') {
       if (tapTempoModeActive) return;
       tapTempoModeActive = true;
       if (tapTempoPanel) tapTempoPanel.classList.remove('hidden');
-      if (tapTempoBtn) tapTempoBtn.classList.add('active');
+      tapTempoButtons.forEach((btn) => btn.classList.add('active'));
       syncWaveformCanvasSize();
       renderWaveform();
       updateCursor();
@@ -1132,13 +1134,15 @@ if (typeof document !== 'undefined') {
       return closest;
     }
 
-    if (tapTempoBtn) {
-      tapTempoBtn.addEventListener('click', () => {
-        if (tapTempoModeActive) {
-          deactivateTapTempoMode();
-        } else {
-          activateTapTempoMode();
-        }
+    if (tapTempoButtons.length) {
+      tapTempoButtons.forEach((btn) => {
+        btn.addEventListener('click', () => {
+          if (tapTempoModeActive) {
+            deactivateTapTempoMode();
+          } else {
+            activateTapTempoMode();
+          }
+        });
       });
     }
 

--- a/styles.css
+++ b/styles.css
@@ -2,62 +2,110 @@
 /* Estilos básicos para la estructura inicial */
 :root {
   --global-font-size: 0.8rem;
+  --layout-width: 1280px;
+  --spacing-unit: 12px;
+  --panel-radius: 14px;
+  --panel-background: #161616;
   font-family: 'Verdana', sans-serif;
 }
+
 body {
   margin: 0;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: flex-start;
   background-color: #111;
   color: #fff;
   font-family: inherit;
   font-size: var(--global-font-size);
+  padding: var(--spacing-unit) 0;
+}
+
+#app-container {
+  width: var(--layout-width);
+  max-width: var(--layout-width);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--spacing-unit);
+  padding: var(--spacing-unit);
+  box-sizing: border-box;
 }
 
 #app-title {
-  margin: 12px 0 6px;
+  margin: 0;
   font-size: 2.2rem;
   font-weight: 700;
+  text-align: center;
 }
 
 #top-menu,
 #bottom-menu {
-  margin: 6px 10px;
-  background: #161616;
-  padding: 8px 10px;
-  border-radius: 10px;
+  background: var(--panel-background);
+  border-radius: var(--panel-radius);
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
+  padding: var(--spacing-unit);
+  display: grid;
+  gap: var(--spacing-unit);
 }
 
 #top-menu {
-  display: grid;
-  gap: 6px;
-  width: min(100%, 960px);
-  box-sizing: border-box;
-  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   align-items: stretch;
 }
 
-#top-menu button,
-#top-menu .fps-control select,
-#top-menu .fps-control input {
-  width: 100%;
+.control-block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-unit);
+  padding: var(--spacing-unit);
+  background: linear-gradient(160deg, #191919, #141414);
+  border-radius: calc(var(--panel-radius) - 2px);
+  border: 1px solid #262626;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 2px 12px rgba(0, 0, 0, 0.25);
 }
 
-#top-menu button {
-  min-height: 32px;
+.control-block-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.control-grid {
+  display: grid;
+  gap: var(--spacing-unit);
+  grid-auto-rows: minmax(44px, auto);
+}
+
+.control-grid.grid-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.control-grid.grid-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.control-grid > button,
+.control-grid > select,
+.control-grid > input {
+  width: 100%;
+  min-height: 44px;
+  box-sizing: border-box;
 }
 
 #fps-control-group {
   display: grid;
-  gap: 6px;
-  padding: 6px 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--spacing-unit);
+  padding: var(--spacing-unit);
   border: 1px solid #2a2a2a;
-  border-radius: 8px;
+  border-radius: 10px;
   background: linear-gradient(160deg, #191919, #141414);
-  align-content: start;
-  grid-column: span 2;
+  align-items: end;
+  grid-column: 1 / -1;
 }
 
 #fps-control-group label {
@@ -67,6 +115,7 @@ body {
 #fps-control-group select,
 #fps-control-group input {
   width: 100%;
+  min-height: 44px;
   box-sizing: border-box;
 }
 
@@ -75,28 +124,20 @@ body {
   cursor: not-allowed;
 }
 
-/* Layout específico para el menú inferior para mantener
-   un formato organizado y simétrico */
 #bottom-menu {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-#toggle-family-panel {
-  flex: 0 0 40px;
-  min-width: 40px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: stretch;
 }
 
 #bottom-menu button {
-  text-align: center;
+  min-height: 44px;
 }
 
-#tap-tempo-mode {
-  flex: 1 1 160px;
-  min-width: 150px;
+#toggle-family-panel {
+  font-size: 1.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 button,
@@ -105,21 +146,21 @@ input {
   background: #2c2c2c;
   border: 1px solid #444;
   color: #fff;
-  padding: 6px 10px;
-  border-radius: 6px;
+  padding: calc(var(--spacing-unit) * 0.5);
+  border-radius: 8px;
   font-size: inherit;
   font-family: inherit;
-  transition: background 0.2s, border-color 0.2s;
+  transition: background 0.2s, border-color 0.2s, transform 0.2s;
 }
 
 .icon-button {
-  width: 36px;
-  min-width: 36px;
-  display: flex;
+  width: 100%;
+  min-height: 44px;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 6px;
-  font-size: 1.1rem;
+  padding: 0;
+  font-size: 1.4rem;
 }
 
 button:hover,
@@ -130,17 +171,30 @@ input:hover {
   cursor: pointer;
 }
 
+button[data-action='tap-tempo'].active {
+  border-color: #ff9800;
+  box-shadow: 0 0 0 2px rgba(255, 152, 0, 0.35);
+  background: linear-gradient(160deg, #2f2110, #1f1409);
+}
+
+button:focus-visible,
+select:focus-visible,
+input:focus-visible {
+  outline: 2px solid #5a5a5a;
+  outline-offset: 2px;
+}
+
 #family-config-panel {
   display: none;
-  margin: 0 10px 12px;
+  margin: 0;
   background: #1a1a1a;
-  padding: 10px;
-  width: calc(100% - 20px);
+  padding: var(--spacing-unit);
+  width: 100%;
   box-sizing: border-box;
   font-size: inherit;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 10px;
-  border-radius: 12px;
+  gap: var(--spacing-unit);
+  border-radius: var(--panel-radius);
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
 }
 
@@ -151,12 +205,12 @@ input:hover {
 #developer-controls {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 8px;
+  gap: var(--spacing-unit);
   width: 100%;
-  margin-bottom: 10px;
-  padding: 10px;
+  margin-bottom: var(--spacing-unit);
+  padding: var(--spacing-unit);
   background: linear-gradient(160deg, #202020, #171717);
-  border-radius: 10px;
+  border-radius: calc(var(--panel-radius) - 2px);
   box-sizing: border-box;
   font-size: inherit;
   grid-column: 1 / -1;
@@ -527,9 +581,13 @@ input:hover {
 }
 
 #visualizer {
+  display: block;
+  width: 100%;
   border: 1px solid #444;
+  border-radius: var(--panel-radius);
   height: 720px;
   background-color: #000;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
 }
 
 #assignment-modal {
@@ -609,12 +667,13 @@ input:hover {
 }
 
 #tap-tempo-panel {
-  margin: 16px auto;
-  max-width: 960px;
+  margin: 0;
+  max-width: var(--layout-width);
+  width: 100%;
   background: rgba(20, 20, 20, 0.9);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 8px;
-  padding: 16px;
+  border-radius: var(--panel-radius);
+  padding: var(--spacing-unit);
   color: #f5f5f5;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
   position: relative;
@@ -627,7 +686,7 @@ input:hover {
 #tap-tempo-controls {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: var(--spacing-unit);
   align-items: center;
   justify-content: space-between;
 }


### PR DESCRIPTION
## Resumen
- Reorganiza `index.html` en un contenedor de ancho fijo con bloques de controles simétricos basados en CSS Grid.
- Ajusta `styles.css` para definir un sistema de espaciado uniforme, nuevos paneles y un canvas alineado con el resto de la interfaz.
- Actualiza `script.js` para gestionar múltiples botones de activación de tap tempo mediante atributos de datos compartidos.

## Pruebas
- No se ejecutaron pruebas automatizadas (cambios únicamente de interfaz).


------
https://chatgpt.com/codex/tasks/task_e_690c240370f483338f07da38bded09a8