### PR TITLE
Adjust defaults for rendering and enable dynamic extensions

### DIFF
--- a/configuracion.js
+++ b/configuracion.js
@@ -59,62 +59,62 @@ window.DEFAULT_CONFIG = {
     "Metales": {
       "color": "#edd113",
       "shape": "roundedSquare",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Cornos": {
       "color": "#edbe13",
       "shape": "roundedSquareDouble",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Maderas de timbre \"redondo\"": {
       "color": "#769df3",
       "shape": "roundedSquare",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Dobles cañas": {
       "color": "#c23afd",
       "shape": "sixPointStar",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Saxofones": {
       "color": "#ce8767",
       "shape": "fourPointStar",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Placas": {
       "color": "#ff0000",
       "shape": "diamondDouble",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Auxiliares": {
       "color": "#347875",
       "shape": "roundedSquareDouble",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Cuerdas frotadas": {
       "color": "#41e342",
       "shape": "diamond",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Cuerdas pulsadas": {
       "color": "#1abeb4",
       "shape": "triangle",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Voces": {
       "color": "#bebebe",
       "shape": "squareDouble",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Custom 1": {
       "color": "#d52b2b",
       "shape": "diamond",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Percusión menor": {
       "color": "#a78269",
       "shape": "square",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     }
   },
   "enabledInstruments": {
@@ -270,16 +270,16 @@ window.DEFAULT_CONFIG = {
     "Percusion": true,
     "Violin": true
   },
-  "velocityBase": 127,
+  "velocityBase": 67,
   "opacityScale": {
     "edge": 0,
-    "mid": 0.5
+    "mid": 1
   },
-  "glowStrength": 1.5,
-  "bumpControl": 1.2,
+  "glowStrength": 0.1,
+  "bumpControl": 1.1,
   "visibleSeconds": 8,
   "heightScale": {
-    "global": 2,
+    "global": 1.8,
     "families": {}
   },
   "shapeExtensions": {

--- a/configuracion.json
+++ b/configuracion.json
@@ -59,62 +59,62 @@
     "Metales": {
       "color": "#edd113",
       "shape": "roundedSquare",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Cornos": {
       "color": "#edbe13",
       "shape": "roundedSquareDouble",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Maderas de timbre \"redondo\"": {
       "color": "#769df3",
       "shape": "roundedSquare",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Dobles cañas": {
       "color": "#c23afd",
       "shape": "sixPointStar",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Saxofones": {
       "color": "#ce8767",
       "shape": "fourPointStar",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Placas": {
       "color": "#ff0000",
       "shape": "diamondDouble",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Auxiliares": {
       "color": "#347875",
       "shape": "roundedSquareDouble",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Cuerdas frotadas": {
       "color": "#41e342",
       "shape": "diamond",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Cuerdas pulsadas": {
       "color": "#1abeb4",
       "shape": "triangle",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Voces": {
       "color": "#bebebe",
       "shape": "squareDouble",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Custom 1": {
       "color": "#d52b2b",
       "shape": "diamond",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     },
     "Percusión menor": {
       "color": "#a78269",
       "shape": "square",
-      "secondaryColor": "#000000"
+      "secondaryColor": "#FFFFFF"
     }
   },
   "enabledInstruments": {
@@ -270,16 +270,16 @@
     "Percusion": true,
     "Violin": true
   },
-  "velocityBase": 127,
+  "velocityBase": 67,
   "opacityScale": {
     "edge": 0,
-    "mid": 0.5
+    "mid": 1
   },
-  "glowStrength": 1.5,
-  "bumpControl": 1.2,
+  "glowStrength": 0.1,
+  "bumpControl": 1.1,
   "visibleSeconds": 8,
   "heightScale": {
-    "global": 2,
+    "global": 1.8,
     "families": {}
   },
   "shapeExtensions": {

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 <body>
   <div id="app-container">
     <h1 id="app-title">Visualizador MIDI - Jaime Jaramillo Arias</h1>
+    <p id="app-subtitle">Basado en el "Music Animation Machine" de Stephen Malinowski.</p>
     <nav id="top-menu">
       <div class="control-block" id="file-controls">
         <h2 class="control-block-title">Archivos y reproducción</h2>

--- a/script.js
+++ b/script.js
@@ -132,6 +132,8 @@ const writeStoredNumber = (key, value) => {
   writeStoredValue(key, String(value));
 };
 
+const DEFAULT_SECONDARY_COLOR = '#FFFFFF';
+
 const readStoredString = (key, fallback, validator = () => true) => {
   const raw = readStoredValue(key);
   if (typeof raw !== 'string') return fallback;
@@ -144,7 +146,7 @@ const enabledInstruments = readStoredJSON('enabledInstruments', {}) || {};
 // Parámetros de fluidez de animación
 const FRAME_DT_MIN = 8;
 const FRAME_DT_MAX = 32;
-let superSampling = 2;
+let superSampling = 1.4;
 
 const FPS_MODE_KEY = 'fpsMode';
 const FIXED_FPS_KEY = 'fixedFps';
@@ -155,7 +157,7 @@ const FIXED_FPS_DEFAULT = 90;
 const FIXED_FPS_MIN = 30;
 const FIXED_FPS_MAX = 240;
 
-let fpsMode = readStoredString(FPS_MODE_KEY, FPS_MODE_FIXED, (value) =>
+let fpsMode = readStoredString(FPS_MODE_KEY, FPS_MODE_AUTO, (value) =>
   FPS_MODE_OPTIONS.includes(value)
 );
 let fixedFPS = readStoredNumber(
@@ -173,7 +175,7 @@ const clampFixedFPS = (value) => {
 };
 
 function setFPSMode(mode) {
-  const normalized = FPS_MODE_OPTIONS.includes(mode) ? mode : FPS_MODE_FIXED;
+  const normalized = FPS_MODE_OPTIONS.includes(mode) ? mode : FPS_MODE_AUTO;
   fpsMode = normalized;
   writeStoredValue(FPS_MODE_KEY, normalized);
   return fpsMode;
@@ -1557,7 +1559,7 @@ if (typeof document !== 'undefined') {
       const preset =
         FAMILY_PRESETS[targetFamily] ||
         FAMILY_DEFAULTS[targetFamily] ||
-        { shape: 'circle', color: '#ffa500', secondaryColor: '#000000' };
+        { shape: 'circle', color: '#ffa500', secondaryColor: DEFAULT_SECONDARY_COLOR };
       track.family = targetFamily;
       const override = instrumentCustomizations[trackName] || null;
       if (!override || !override.shape) {
@@ -1566,7 +1568,7 @@ if (typeof document !== 'undefined') {
       if (!override || !override.color) {
         track.color = getInstrumentColor(preset);
       }
-      track.secondaryColor = preset.secondaryColor || '#000000';
+      track.secondaryColor = preset.secondaryColor || DEFAULT_SECONDARY_COLOR;
       if (override) {
         override.family = targetFamily;
       }
@@ -1823,14 +1825,14 @@ if (typeof document !== 'undefined') {
         let mixed = false;
         families.forEach((family) => {
           const preset = FAMILY_PRESETS[family] || {};
-          const color = (preset.secondaryColor || '#000000').toLowerCase();
+          const color = (preset.secondaryColor || DEFAULT_SECONDARY_COLOR).toLowerCase();
           if (baseColor === null) {
             baseColor = color;
           } else if (baseColor !== color) {
             mixed = true;
           }
         });
-        if (baseColor === null) baseColor = '#000000';
+        if (baseColor === null) baseColor = DEFAULT_SECONDARY_COLOR;
         return { color: baseColor, mixed };
       };
 
@@ -2370,7 +2372,7 @@ if (typeof document !== 'undefined') {
       instrumentOutlineColorLabel.textContent = 'Color del contorno:';
       const instrumentOutlineColorInput = document.createElement('input');
       instrumentOutlineColorInput.type = 'color';
-      instrumentOutlineColorInput.value = '#ffffff';
+      instrumentOutlineColorInput.value = '#FFFFFF';
       const instrumentOutlineColorAutoLabel = document.createElement('label');
       instrumentOutlineColorAutoLabel.className = 'outline-color-auto';
       const instrumentOutlineColorAuto = document.createElement('input');
@@ -2448,7 +2450,7 @@ if (typeof document !== 'undefined') {
           applyInstrumentOutlineUpdate({ color: null });
         } else {
           instrumentOutlineColorInput.disabled = false;
-          applyInstrumentOutlineUpdate({ color: instrumentOutlineColorInput.value || '#ffffff' });
+          applyInstrumentOutlineUpdate({ color: instrumentOutlineColorInput.value || '#FFFFFF' });
         }
       });
 
@@ -2558,7 +2560,7 @@ if (typeof document !== 'undefined') {
           instrumentOutlineOpacityHint.textContent = '';
           instrumentOutlineOpacityHint.classList.add('hint-active');
           instrumentOutlineColorAuto.checked = true;
-          instrumentOutlineColorInput.value = '#ffffff';
+          instrumentOutlineColorInput.value = '#FFFFFF';
           instrumentOutlineColorHint.textContent = '';
           instrumentOutlineColorHint.classList.add('hint-active');
           return;
@@ -2674,7 +2676,7 @@ if (typeof document !== 'undefined') {
         const effectiveColor = effectiveOutline.color || null;
         instrumentOutlineColorAuto.checked = effectiveColor === null;
         instrumentOutlineColorInput.disabled = instrumentOutlineColorAuto.checked;
-        instrumentOutlineColorInput.value = effectiveColor || '#ffffff';
+        instrumentOutlineColorInput.value = effectiveColor || '#FFFFFF';
         if (outlineHas('color')) {
           if (outlineOverride.color === null) {
             instrumentOutlineColorHint.textContent = 'Forzado al color de la figura';
@@ -2868,14 +2870,14 @@ if (typeof document !== 'undefined') {
       secondaryLabel.textContent = 'Color secundario:';
       const secondaryInput = document.createElement('input');
       secondaryInput.type = 'color';
-      secondaryInput.value = '#000000';
+      secondaryInput.value = DEFAULT_SECONDARY_COLOR;
       const secondaryHint = document.createElement('span');
       secondaryHint.className = 'control-hint';
 
       updateSecondaryColorControl = () => {
         const { color, mixed } = getSecondaryColorState(familyTargetSelect.value);
         if (mixed) {
-          secondaryInput.value = '#000000';
+          secondaryInput.value = DEFAULT_SECONDARY_COLOR;
           secondaryHint.textContent = 'Valores variados';
           secondaryHint.classList.add('hint-active');
         } else {
@@ -3202,7 +3204,7 @@ if (typeof document !== 'undefined') {
       outlineColorLabel.textContent = 'Color del contorno:';
       const outlineColorInput = document.createElement('input');
       outlineColorInput.type = 'color';
-      outlineColorInput.value = '#ffffff';
+      outlineColorInput.value = '#FFFFFF';
       const outlineColorAutoLabel = document.createElement('label');
       outlineColorAutoLabel.className = 'outline-color-auto';
       const outlineColorAuto = document.createElement('input');
@@ -3241,7 +3243,7 @@ if (typeof document !== 'undefined') {
           outlineColorAuto.indeterminate = false;
           outlineColorAuto.checked = color === null;
           outlineColorInput.disabled = outlineColorAuto.checked;
-          outlineColorInput.value = color || '#ffffff';
+          outlineColorInput.value = color || '#FFFFFF';
           if (color) {
             outlineColorHint.textContent = color.toUpperCase();
             outlineColorHint.classList.remove('hint-active');
@@ -3332,8 +3334,8 @@ if (typeof document !== 'undefined') {
           outlineColorHint.textContent = 'Color de la figura';
           outlineColorHint.classList.add('hint-active');
         } else {
-          outlineColorInput.value = colorBase || '#ffffff';
-          outlineColorHint.textContent = (colorBase || '#ffffff').toUpperCase();
+          outlineColorInput.value = colorBase || '#FFFFFF';
+          outlineColorHint.textContent = (colorBase || '#FFFFFF').toUpperCase();
           outlineColorHint.classList.remove('hint-active');
         }
       };
@@ -3402,7 +3404,7 @@ if (typeof document !== 'undefined') {
         if (outlineColorAuto.checked) {
           applyOutlineUpdate({ color: null });
         } else {
-          applyOutlineUpdate({ color: outlineColorInput.value || '#ffffff' });
+          applyOutlineUpdate({ color: outlineColorInput.value || '#FFFFFF' });
         }
       });
 
@@ -4236,7 +4238,7 @@ if (typeof document !== 'undefined') {
               velocity: ev.velocity,
               color: track.color || '#ffa500',
               shape: track.shape || 'circle',
-              secondaryColor: track.secondaryColor || '#000000',
+              secondaryColor: track.secondaryColor || DEFAULT_SECONDARY_COLOR,
               family: track.family,
               instrument: track.instrument,
               trackName: track.name,
@@ -4663,25 +4665,93 @@ const FAMILY_DEFAULTS = {
   'Maderas de timbre "redondo"': {
     shape: 'roundedSquare',
     color: '#0000ff',
-    secondaryColor: '#000000',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
   },
-  'Dobles cañas': { shape: 'sixPointStar', color: '#8a2be2', secondaryColor: '#000000' },
-  'Saxofones': { shape: 'fourPointStar', color: '#a0522d', secondaryColor: '#000000' },
-  Metales: { shape: 'roundedSquare', color: '#ffff00', secondaryColor: '#000000' },
-  Cornos: { shape: 'roundedSquareDouble', color: '#ffff00', secondaryColor: '#000000' },
-  'Percusión menor': { shape: 'square', color: '#808080', secondaryColor: '#000000' },
-  Tambores: { shape: 'circle', color: '#808080', secondaryColor: '#000000' },
-  Platillos: { shape: 'circleDouble', color: '#808080', secondaryColor: '#000000' },
-  Placas: { shape: 'diamondDouble', color: '#ff0000', secondaryColor: '#000000' },
-  Auxiliares: { shape: 'roundedSquareDouble', color: '#4b0082', secondaryColor: '#000000' },
-  'Cuerdas frotadas': { shape: 'diamond', color: '#ffa500', secondaryColor: '#000000' },
-  'Cuerdas pulsadas': { shape: 'triangle', color: '#008000', secondaryColor: '#000000' },
-  Voces: { shape: 'squareDouble', color: '#808080', secondaryColor: '#000000' },
-  'Custom 1': { shape: 'square', color: '#ffffff', secondaryColor: '#000000' },
-  'Custom 2': { shape: 'square', color: '#ffffff', secondaryColor: '#000000' },
-  'Custom 3': { shape: 'square', color: '#ffffff', secondaryColor: '#000000' },
-  'Custom 4': { shape: 'square', color: '#ffffff', secondaryColor: '#000000' },
-  'Custom 5': { shape: 'square', color: '#ffffff', secondaryColor: '#000000' },
+  'Dobles cañas': {
+    shape: 'sixPointStar',
+    color: '#8a2be2',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
+  },
+  'Saxofones': {
+    shape: 'fourPointStar',
+    color: '#a0522d',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
+  },
+  Metales: {
+    shape: 'roundedSquare',
+    color: '#ffff00',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
+  },
+  Cornos: {
+    shape: 'roundedSquareDouble',
+    color: '#ffff00',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
+  },
+  'Percusión menor': {
+    shape: 'square',
+    color: '#808080',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
+  },
+  Tambores: {
+    shape: 'circle',
+    color: '#808080',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
+  },
+  Platillos: {
+    shape: 'circleDouble',
+    color: '#808080',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
+  },
+  Placas: {
+    shape: 'diamondDouble',
+    color: '#ff0000',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
+  },
+  Auxiliares: {
+    shape: 'roundedSquareDouble',
+    color: '#4b0082',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
+  },
+  'Cuerdas frotadas': {
+    shape: 'diamond',
+    color: '#ffa500',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
+  },
+  'Cuerdas pulsadas': {
+    shape: 'triangle',
+    color: '#008000',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
+  },
+  Voces: {
+    shape: 'squareDouble',
+    color: '#808080',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
+  },
+  'Custom 1': {
+    shape: 'square',
+    color: '#FFFFFF',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
+  },
+  'Custom 2': {
+    shape: 'square',
+    color: '#FFFFFF',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
+  },
+  'Custom 3': {
+    shape: 'square',
+    color: '#FFFFFF',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
+  },
+  'Custom 4': {
+    shape: 'square',
+    color: '#FFFFFF',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
+  },
+  'Custom 5': {
+    shape: 'square',
+    color: '#FFFFFF',
+    secondaryColor: DEFAULT_SECONDARY_COLOR,
+  },
 };
 
 // Copia mutable de los valores predeterminados
@@ -4804,7 +4874,7 @@ if (typeof localStorage !== 'undefined') {
     if (cfg.secondaryColor) {
       preset.secondaryColor = cfg.secondaryColor;
     } else if (!preset.secondaryColor) {
-      preset.secondaryColor = '#000000';
+      preset.secondaryColor = DEFAULT_SECONDARY_COLOR;
     }
     let resolvedColor = cfg.color;
     if (!resolvedColor && cfg.colorBright && cfg.colorDark) {
@@ -5070,7 +5140,7 @@ function renderOutline(
   const opacity = typeof outlineConfig.opacity === 'number' ? outlineConfig.opacity : 1;
   const intensity = clamp(baseAlpha * opacity, 0, 1);
   if (!(intensity > 0)) return;
-  const strokeColor = outlineConfig.color || note.color || '#ffffff';
+  const strokeColor = outlineConfig.color || note.color || '#FFFFFF';
   const strokeWidth =
     typeof outlineConfig.width === 'number' && Number.isFinite(outlineConfig.width)
       ? outlineConfig.width
@@ -5216,7 +5286,11 @@ function setFamilyCustomization(
   { force = false } = {},
 ) {
   const basePreset =
-    FAMILY_PRESETS[family] || { shape: 'circle', color: '#ffa500', secondaryColor: '#000000' };
+    FAMILY_PRESETS[family] || {
+      shape: 'circle',
+      color: '#ffa500',
+      secondaryColor: DEFAULT_SECONDARY_COLOR,
+    };
   const preset = { ...basePreset };
   let resolvedColor = color;
   if (!resolvedColor && colorBright && colorDark) {
@@ -5234,7 +5308,7 @@ function setFamilyCustomization(
   if (secondaryColor) {
     preset.secondaryColor = secondaryColor;
   } else if (!preset.secondaryColor) {
-    preset.secondaryColor = '#000000';
+    preset.secondaryColor = DEFAULT_SECONDARY_COLOR;
   }
   FAMILY_PRESETS[family] = {
     shape: preset.shape,
@@ -5361,7 +5435,7 @@ function setInstrumentCustomization(
     if (validShape) {
       note.shape = validShape;
     }
-    note.secondaryColor = track.secondaryColor || '#000000';
+    note.secondaryColor = track.secondaryColor || DEFAULT_SECONDARY_COLOR;
   });
 }
 
@@ -5379,10 +5453,10 @@ function clearInstrumentCustomization(
   const preset =
     FAMILY_PRESETS[track.family] ||
     FAMILY_DEFAULTS[track.family] ||
-    { shape: 'circle', color: '#ffa500', secondaryColor: '#000000' };
+    { shape: 'circle', color: '#ffa500', secondaryColor: DEFAULT_SECONDARY_COLOR };
   track.shape = preset.shape;
   track.color = getInstrumentColor(preset);
-  track.secondaryColor = preset.secondaryColor || '#000000';
+  track.secondaryColor = preset.secondaryColor || DEFAULT_SECONDARY_COLOR;
   const effectiveFrom = typeof fromTime === 'number' && fromTime > 0 ? fromTime : 0;
   notes.forEach((note) => {
     if ((note.trackName ?? note.instrument) !== trackName) return;
@@ -5408,17 +5482,25 @@ function resetFamilyCustomizations(tracks = [], notes = []) {
   resetOutlineSettings();
   tracks.forEach((t) => {
     const preset =
-      FAMILY_PRESETS[t.family] || { shape: 'circle', color: '#ffa500', secondaryColor: '#000000' };
+      FAMILY_PRESETS[t.family] || {
+        shape: 'circle',
+        color: '#ffa500',
+        secondaryColor: DEFAULT_SECONDARY_COLOR,
+      };
     t.shape = preset.shape;
     t.color = getInstrumentColor(preset);
-    t.secondaryColor = preset.secondaryColor || '#000000';
+    t.secondaryColor = preset.secondaryColor || DEFAULT_SECONDARY_COLOR;
   });
   notes.forEach((n) => {
     const preset =
-      FAMILY_PRESETS[n.family] || { shape: 'circle', color: '#ffa500', secondaryColor: '#000000' };
+      FAMILY_PRESETS[n.family] || {
+        shape: 'circle',
+        color: '#ffa500',
+        secondaryColor: DEFAULT_SECONDARY_COLOR,
+      };
     n.shape = preset.shape;
     n.color = getInstrumentColor(preset);
-    n.secondaryColor = preset.secondaryColor || '#000000';
+    n.secondaryColor = preset.secondaryColor || DEFAULT_SECONDARY_COLOR;
   });
   if (typeof renderFrame === 'function') {
     renderFrame(lastTime);
@@ -5555,7 +5637,7 @@ function importConfiguration(json, tracks = [], notes = []) {
     if (cfg.secondaryColor) {
       preset.secondaryColor = cfg.secondaryColor;
     } else if (!preset.secondaryColor) {
-      preset.secondaryColor = '#000000';
+      preset.secondaryColor = DEFAULT_SECONDARY_COLOR;
     }
     let resolvedColor = cfg.color;
     if (!resolvedColor && cfg.colorBright && cfg.colorDark) {
@@ -5598,20 +5680,28 @@ function importConfiguration(json, tracks = [], notes = []) {
     const fam = assignedFamilies[t.name] || t.family;
     t.family = fam;
     const preset =
-      FAMILY_PRESETS[fam] || { shape: 'circle', color: '#ffa500', secondaryColor: '#000000' };
+      FAMILY_PRESETS[fam] || {
+        shape: 'circle',
+        color: '#ffa500',
+        secondaryColor: DEFAULT_SECONDARY_COLOR,
+      };
     t.shape = preset.shape;
     t.color = getInstrumentColor(preset);
-    t.secondaryColor = preset.secondaryColor || '#000000';
+    t.secondaryColor = preset.secondaryColor || DEFAULT_SECONDARY_COLOR;
   });
   notes.forEach((n) => {
     const key = n.trackName ?? n.instrument;
     const fam = assignedFamilies[key] || n.family;
     n.family = fam;
     const preset =
-      FAMILY_PRESETS[fam] || { shape: 'circle', color: '#ffa500', secondaryColor: '#000000' };
+      FAMILY_PRESETS[fam] || {
+        shape: 'circle',
+        color: '#ffa500',
+        secondaryColor: DEFAULT_SECONDARY_COLOR,
+      };
     n.shape = preset.shape;
     n.color = getInstrumentColor(preset);
-    n.secondaryColor = preset.secondaryColor || '#000000';
+    n.secondaryColor = preset.secondaryColor || DEFAULT_SECONDARY_COLOR;
   });
   applyInstrumentCustomizationsToData(tracks, notes);
 }
@@ -5648,7 +5738,11 @@ function assignTrackInfo(tracks) {
     const instrument = resolveInstrumentName(t.name);
     const family = INSTRUMENT_FAMILIES[instrument] || 'Desconocida';
     const preset =
-      FAMILY_PRESETS[family] || { shape: 'circle', color: '#ffa500', secondaryColor: '#000000' };
+      FAMILY_PRESETS[family] || {
+        shape: 'circle',
+        color: '#ffa500',
+        secondaryColor: DEFAULT_SECONDARY_COLOR,
+      };
     const color = getInstrumentColor(preset);
     return {
       ...t,
@@ -5656,7 +5750,7 @@ function assignTrackInfo(tracks) {
       family,
       shape: preset.shape,
       color,
-      secondaryColor: preset.secondaryColor || '#000000',
+      secondaryColor: preset.secondaryColor || DEFAULT_SECONDARY_COLOR,
       detectedFamily: family,
       detectedShape: preset.shape,
       detectedColor: color,

--- a/styles.css
+++ b/styles.css
@@ -41,6 +41,14 @@ body {
   text-align: center;
 }
 
+#app-subtitle {
+  margin: 0;
+  margin-top: 4px;
+  font-size: 0.95rem;
+  text-align: center;
+  color: #d0d0d0;
+}
+
 #top-menu,
 #bottom-menu {
   background: var(--panel-background);

--- a/test_family_modifiers.js
+++ b/test_family_modifiers.js
@@ -2,24 +2,28 @@ const assert = require('assert');
 const { getFamilyModifiers, computeNoteWidth } = require('./script');
 
 // Modificadores de familia
+function approx(actual, expected, eps = 1e-6) {
+  assert(Math.abs(actual - expected) < eps, `${actual} != ${expected}`);
+}
+
 const platillos = getFamilyModifiers('Platillos');
-assert.strictEqual(platillos.sizeFactor, 1.3);
-assert.strictEqual(platillos.bump, 0.5);
+approx(platillos.sizeFactor, 1.3);
+approx(platillos.bump, 0.5);
 
 const auxiliares = getFamilyModifiers('Auxiliares');
-assert.strictEqual(auxiliares.bump, 0.8);
+approx(auxiliares.bump, 0.8);
 
 const defaultMods = getFamilyModifiers('Desconocida');
-assert.strictEqual(defaultMods.sizeFactor, 1);
+approx(defaultMods.sizeFactor, 1);
 
 // Cálculo del ancho para figuras no alargadas
 const notePlatillos = { start: 0, end: 1, shape: 'circle', family: 'Platillos' };
-assert.strictEqual(computeNoteWidth(notePlatillos, 10, 20), 26);
+approx(computeNoteWidth(notePlatillos, 10, 20), 23.4);
 
 const noteTambores = { start: 0, end: 1, shape: 'circle', family: 'Tambores' };
-assert.strictEqual(computeNoteWidth(noteTambores, 10, 20), 20);
+approx(computeNoteWidth(noteTambores, 10, 20), 18);
 
 const sustainedDouble = { start: 0, end: 2, shape: 'circleDouble', family: 'Tambores' };
-assert.strictEqual(computeNoteWidth(sustainedDouble, 10, 20), 20);
+approx(computeNoteWidth(sustainedDouble, 10, 20), 18);
 
 console.log('Pruebas de modificadores de familia completadas');

--- a/test_fps_controls_removed.js
+++ b/test_fps_controls_removed.js
@@ -12,11 +12,11 @@ const html = fs.readFileSync('index.html', 'utf8');
 assert(html.includes('id="fps-mode"'));
 assert(html.includes('id="fps-value"'));
 
-assert.strictEqual(getFPSMode(), 'fixed');
-setFPSMode('auto');
 assert.strictEqual(getFPSMode(), 'auto');
-setFPSMode('invalid');
+setFPSMode('fixed');
 assert.strictEqual(getFPSMode(), 'fixed');
+setFPSMode('invalid');
+assert.strictEqual(getFPSMode(), 'auto');
 
 assert.strictEqual(getFixedFPS(), 90);
 setFixedFPS(500);

--- a/test_opacity_scale.js
+++ b/test_opacity_scale.js
@@ -13,6 +13,6 @@ approx(scale.mid, 0.8);
 approx(computeOpacity(-50, 50, 600), 0.1);
 approx(computeOpacity(125, 175, 600), 0.45);
 
-setOpacityScale(0, 0.5);
+setOpacityScale(0, 1);
 
 console.log('Pruebas de escala de opacidad configurables completadas');

--- a/test_outline_settings.js
+++ b/test_outline_settings.js
@@ -55,7 +55,7 @@ const tracks = [
     detectedFamily: FAMILY,
     shape: 'circle',
     color: '#ffffff',
-    secondaryColor: '#000000',
+    secondaryColor: '#FFFFFF',
   },
 ];
 const notes = [];

--- a/test_shape_extension_control.js
+++ b/test_shape_extension_control.js
@@ -36,7 +36,7 @@ setShapeExtensionsEnabled(false);
 assert.strictEqual(getShapeExtension('circle'), false);
 setShapeExtensionsEnabled(true);
 assert.strictEqual(getShapeExtension('circle'), true);
-assert.strictEqual(getShapeExtension('circleDouble'), false);
+assert.strictEqual(getShapeExtension('circleDouble'), true);
 
 setShapeStretchEnabled(false);
 assert.strictEqual(getShapeStretch('circle'), false);
@@ -51,12 +51,22 @@ const doubleNote = {
 };
 result = computeDynamicBounds(
   doubleNote,
-  2,
+  1,
   canvasWidth,
   pixelsPerSecond,
   baseWidth,
   'circleDouble',
 );
 assert.strictEqual(result.width, baseWidth);
+
+result = computeDynamicBounds(
+  doubleNote,
+  2,
+  canvasWidth,
+  pixelsPerSecond,
+  baseWidth,
+  'circleDouble',
+);
+assert.strictEqual(result.width, baseWidth + (finalWidth - baseWidth) / 2);
 
 console.log('Pruebas de control de extensión de figuras completadas');

--- a/test_velocity_height.js
+++ b/test_velocity_height.js
@@ -2,13 +2,21 @@ const assert = require('assert');
 const { computeVelocityHeight, computeBumpHeight } = require('./script');
 
 const base = 10;
-assert.strictEqual(computeVelocityHeight(base, 127), base);
-assert.strictEqual(computeVelocityHeight(base, 254), base * 2);
-assert(Math.abs(computeVelocityHeight(base, 33) - base * (33 / 127)) < 1e-6);
+const reference = 67;
+assert.strictEqual(computeVelocityHeight(base, reference), base);
+assert.strictEqual(computeVelocityHeight(base, reference * 2), base * 2);
+assert(
+  Math.abs(computeVelocityHeight(base, 34) - base * (34 / reference)) < 1e-6,
+);
 
 // Verifica que la altura del bump también escala con la velocidad
-const bumpBase = computeBumpHeight(computeVelocityHeight(base, 127), 0, 0, 1);
-const bumpDouble = computeBumpHeight(computeVelocityHeight(base, 254), 0, 0, 1);
+const bumpBase = computeBumpHeight(computeVelocityHeight(base, reference), 0, 0, 1);
+const bumpDouble = computeBumpHeight(
+  computeVelocityHeight(base, reference * 2),
+  0,
+  0,
+  1,
+);
 assert.strictEqual(bumpDouble, bumpBase * 2);
 
 console.log('Pruebas de altura por velocidad completadas');

--- a/test_velocity_note_render.js
+++ b/test_velocity_note_render.js
@@ -80,10 +80,14 @@ dom.window.__setTestNotes(notes);
 dom.window.__renderFrame(1.3);
 
 const rects = contexts[1].rects;
-assert.strictEqual(rects.length, 2, 'Debe dibujar dos rectángulos de contorno tras el note off');
+const uniqueHeights = [...new Set(rects.map((rect) => rect.h))];
+assert.strictEqual(
+  uniqueHeights.length,
+  2,
+  'Debe dibujar dos rectángulos de contorno tras el note off',
+);
 
-const h1 = rects[0].h;
-const h2 = rects[1].h;
+const [h1, h2] = uniqueHeights.sort((a, b) => a - b);
 
 const expectedH1 = Math.round(baseHeight * 2) / 2;
 const expectedH2 = Math.round(baseHeight * 4) / 2;

--- a/test_visual_effects.js
+++ b/test_visual_effects.js
@@ -13,13 +13,13 @@ function approx(actual, expected, eps = 1e-6) {
 }
 
 // Pruebas para computeOpacity
-approx(computeOpacity(250, 350, 600), 0.5); // Nota cruzando el centro con escala por defecto
+approx(computeOpacity(250, 350, 600), 1); // Nota cruzando el centro con escala por defecto
 approx(computeOpacity(-50, 50, 600), 0); // Nota lejos del centro
-approx(computeOpacity(125, 175, 600), 0.25); // Nota a mitad de distancia
+approx(computeOpacity(125, 175, 600), 0.5); // Nota a mitad de distancia
 setOpacityScale(0, 1);
 approx(computeOpacity(250, 350, 600), 1); // Centro al 100%
 approx(computeOpacity(125, 175, 600), 0.5); // Gradiente progresivo
-setOpacityScale(0, 0.5);
+setOpacityScale(0, 1);
 
 // Pruebas para computeBumpHeight
 const base = 10;
@@ -27,18 +27,27 @@ approx(computeBumpHeight(base, -0.1, 0, 1), base); // Antes de la nota
 approx(computeBumpHeight(base, 0, 0, 1), base); // Inicio sin incremento instantáneo
 approx(
   computeBumpHeight(base, 0.12, 0, 1),
-  13.8134110787,
+  13.7064308604,
   1e-6,
 ); // Aumento progresivo rápido
-approx(computeBumpHeight(base, 0.42, 0, 1), 16); // Pico del bump (120%)
-approx(computeBumpHeight(base, 0.9, 0, 1), 10.888, 1e-3); // Decaimiento cercano al final
+approx(computeBumpHeight(base, 0.42, 0, 1), 14.9747175901); // Pico del bump (110%)
+approx(
+  computeBumpHeight(base, 0.9, 0, 1),
+  10.4303388919,
+  1e-6,
+); // Decaimiento cercano al final
 approx(computeBumpHeight(base, 1.2, 0, 1), base); // Regreso tras la extensión del bump
-approx(computeBumpHeight(base, 0.42, 0, 1, 0.8), 19.6); // Bump incrementado
+approx(
+  computeBumpHeight(base, 0.42, 0, 1, 0.8),
+  17.9595481442,
+  1e-6,
+); // Bump incrementado
 
 // Pruebas para computeGlowAlpha
 approx(computeGlowAlpha(0, 0), 1); // Inicio del brillo
-approx(computeGlowAlpha(0.1, 0), 2 / 3); // Mitad del efecto extendido
-approx(computeGlowAlpha(0.3, 0), 0); // Efecto terminado
+approx(computeGlowAlpha(0.005, 0), 0.75); // Primer tramo del efecto con glow predeterminado
+approx(computeGlowAlpha(0.01, 0), 0.5); // Mitad del efecto con glow predeterminado
+approx(computeGlowAlpha(0.02, 0), 0); // Efecto terminado
 
 function brightness(hex) {
   const normalized = hex.replace('#', '');

--- a/utils.js
+++ b/utils.js
@@ -79,13 +79,13 @@ function validateColorRange(bright, dark) {
     lumDark = getLuminance(dark);
     diff = lumBright - lumDark;
     iterations++;
-    if (bright === '#ffffff' && dark === '#000000') break;
+    if (bright === '#FFFFFF' && dark === '#000000') break;
   }
   return { bright, dark };
 }
 
 // Parámetros configurables de opacidad
-let opacityScale = { edge: 0, mid: 0.5 };
+let opacityScale = { edge: 0, mid: 1 };
 
 function setOpacityScale(edge, mid) {
   opacityScale = { edge, mid };
@@ -125,7 +125,7 @@ function computeOpacity(xStart, xEnd, canvasWidth) {
 }
 
 // Control global y por familia para el efecto "bump"
-let bumpControl = 1.2;
+let bumpControl = 1.1;
 let familyBumpControl = {};
 
 function persistBumpControl() {
@@ -241,7 +241,7 @@ function computeBumpHeight(
 }
 
 // Referencia de velocidad MIDI para altura 100%
-let velocityBase = 127;
+let velocityBase = 67;
 
 // Permite definir una nueva velocidad base
 function setVelocityBase(value) {
@@ -268,7 +268,7 @@ function computeVelocityHeight(baseHeight, velocity, reference = velocityBase) {
 }
 
 // Escala global o por familia para la altura de las figuras
-let heightScale = 2;
+let heightScale = 1.8;
 let familyHeightScale = {};
 
 function persistHeightScale() {
@@ -319,7 +319,7 @@ function getHeightScaleConfig() {
 loadHeightScale();
 
 // Control global y por familia del glow
-let glowStrength = 1.5;
+let glowStrength = 0.1;
 let familyGlowStrength = {};
 
 function persistGlowStrength() {
@@ -426,7 +426,7 @@ function lightenHexColor(hex, factor) {
   const normalized = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
   const eased = easeOutCubic(Math.min(Math.max(factor, 0), 1));
   const mixFactor = Math.min(1, eased * 0.9);
-  return interpolateColor(normalized, '#ffffff', mixFactor);
+  return interpolateColor(normalized, '#FFFFFF', mixFactor);
 }
 
 // Ajusta el tono del color base para simular el antiguo resplandor en el NOTE ON
@@ -572,9 +572,14 @@ function traceHexagon(ctx, x, y, width, height, inset = 0) {
   const halfWidth = effectiveWidth / 2;
   const halfHeight = effectiveHeight / 2;
 
-  ctx.moveTo(centerX, centerY - halfHeight);
+  const rotation = Math.PI / 2;
+  const startAngle = -Math.PI / 2 + rotation;
+  ctx.moveTo(
+    centerX + halfWidth * Math.cos(startAngle),
+    centerY + halfHeight * Math.sin(startAngle),
+  );
   for (let i = 1; i < 6; i++) {
-    const angle = -Math.PI / 2 + (i * Math.PI) / 3;
+    const angle = startAngle + (i * Math.PI) / 3;
     const px = centerX + halfWidth * Math.cos(angle);
     const py = centerY + halfHeight * Math.sin(angle);
     ctx.lineTo(px, py);
@@ -646,7 +651,7 @@ const SHAPE_METADATA = {
         },
       },
     ],
-    secondaryFill: '#000000',
+    secondaryFill: '#FFFFFF',
     draw(ctx, x, y, width, height) {
       traceEllipse(ctx, x, y, width, height);
     },
@@ -683,7 +688,7 @@ const SHAPE_METADATA = {
         },
       },
     ],
-    secondaryFill: '#000000',
+    secondaryFill: '#FFFFFF',
     draw(ctx, x, y, width, height) {
       ctx.rect(x, y, width, height);
     },
@@ -721,7 +726,7 @@ const SHAPE_METADATA = {
         },
       },
     ],
-    secondaryFill: '#000000',
+    secondaryFill: '#FFFFFF',
     draw(ctx, x, y, width, height) {
       const radius = Math.min(width, height) * 0.25;
       traceRoundedSquare(ctx, x, y, width, height, radius);
@@ -763,7 +768,7 @@ const SHAPE_METADATA = {
         },
       },
     ],
-    secondaryFill: '#000000',
+    secondaryFill: '#FFFFFF',
     draw(ctx, x, y, width, height) {
       traceDiamond(ctx, x, y, width, height);
     },
@@ -800,7 +805,7 @@ const SHAPE_METADATA = {
         },
       },
     ],
-    secondaryFill: '#000000',
+    secondaryFill: '#FFFFFF',
     draw(ctx, x, y, width, height) {
       traceHexagon(ctx, x, y, width, height);
     },
@@ -843,7 +848,7 @@ const SHAPE_METADATA = {
         },
       },
     ],
-    secondaryFill: '#000000',
+    secondaryFill: '#FFFFFF',
     draw(ctx, x, y, width, height) {
       traceFourPointStar(ctx, x, y, width, height);
     },
@@ -887,7 +892,7 @@ const SHAPE_METADATA = {
         },
       },
     ],
-    secondaryFill: '#000000',
+    secondaryFill: '#FFFFFF',
   },
   triangle: {
     label: 'Triángulo',
@@ -925,7 +930,7 @@ const SHAPE_METADATA = {
         },
       },
     ],
-    secondaryFill: '#000000',
+    secondaryFill: '#FFFFFF',
     draw(ctx, x, y, width, height) {
       traceTriangle(ctx, x, y, width, height);
     },
@@ -951,30 +956,20 @@ const SHAPE_ORDER = [
   'triangleDouble',
 ];
 
-const NON_EXTENDABLE_SHAPES = new Set([
-  'circleDouble',
-  'squareDouble',
-  'roundedSquareDouble',
-  'diamondDouble',
-  'hexagonDouble',
-  'fourPointStarDouble',
-  'sixPointStar',
-  'sixPointStarDouble',
-  'triangleDouble',
-]);
+const NON_EXTENDABLE_SHAPES = new Set();
 
 const SHAPE_OPTIONS = SHAPE_ORDER.map((value) => ({ value, label: SHAPE_METADATA[value].label }));
 
 const DOUBLE_SHAPE_PATTERN = /double$/i;
-const DEFAULT_SECONDARY_LAYER_COLOR = '#000000';
+const DEFAULT_SECONDARY_LAYER_COLOR = '#FFFFFF';
 const isDoubleShape = (shape) => typeof shape === 'string' && DOUBLE_SHAPE_PATTERN.test(shape);
 
 const OUTLINE_MODES = ['full', 'pre', 'post'];
 const OUTLINE_DEFAULTS = Object.freeze({
-  enabled: false,
+  enabled: true,
   mode: 'full',
-  width: 3,
-  color: null,
+  width: 2.5,
+  color: '#FFFFFF',
   opacity: 1,
 });
 let outlineSettings = { ...OUTLINE_DEFAULTS };
@@ -1157,14 +1152,14 @@ function drawNoteShape(
 
 // Estado de alargamiento progresivo por figura alargada
 const SHAPE_EXTENSION_DEFAULTS = SHAPE_ORDER.reduce((acc, value) => {
-  acc[value] = !isDoubleShape(value) && !NON_EXTENDABLE_SHAPES.has(value);
+  acc[value] = !NON_EXTENDABLE_SHAPES.has(value);
   return acc;
 }, {});
 let shapeExtensions = { ...SHAPE_EXTENSION_DEFAULTS };
 let familyShapeExtensions = {};
 
 const SHAPE_STRETCH_DEFAULTS = SHAPE_ORDER.reduce((acc, value) => {
-  acc[value] = !isDoubleShape(value) && !NON_EXTENDABLE_SHAPES.has(value);
+  acc[value] = !NON_EXTENDABLE_SHAPES.has(value);
   return acc;
 }, {});
 let shapeStretch = { ...SHAPE_STRETCH_DEFAULTS };
@@ -1197,15 +1192,10 @@ function loadShapeExtensions() {
   NON_EXTENDABLE_SHAPES.forEach((shape) => {
     shapeExtensions[shape] = false;
   });
-  Object.keys(shapeExtensions).forEach((shape) => {
-    if (isDoubleShape(shape)) {
-      shapeExtensions[shape] = false;
-    }
-  });
 }
 
 function isShapeExtendable(shape) {
-  return !!(shape && !isDoubleShape(shape) && !NON_EXTENDABLE_SHAPES.has(shape));
+  return !!(shape && !NON_EXTENDABLE_SHAPES.has(shape));
 }
 
 function getShapeExtension(shape) {
@@ -1419,7 +1409,7 @@ function isStretchEnabledForFamily(shape, family) {
 loadShapeExtensions();
 loadShapeStretch();
 
-const DEFAULT_LINE_SETTINGS = { enabled: false, opacity: 0.3, width: 8 };
+const DEFAULT_LINE_SETTINGS = { enabled: true, opacity: 0.3, width: 4.2 };
 let familyLineSettings = {};
 let familyTravelSettings = {};
 const DEFAULT_TRAVEL_EFFECT = true;


### PR DESCRIPTION
## Summary
- enable dynamic stretching/extension for all shapes, rotate the hexagon, and update outline/connection defaults
- set new global defaults for velocity, height, glow, opacity, bump, supersampling, FPS mode, and white secondary colors
- add a subtitle credit below the title and refresh tests to reflect the new behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690c2c8d6d8883339a427a457eae0198