### PR TITLE
Suaviza la curva magnética de notas entrantes

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1587,23 +1587,34 @@ function applyTravelCurve(offset, canvasWidth) {
   let adjustedNormalized = normalized;
 
   if (offset > 0) {
-    const magnetZone = 0.22;
-    const slowExponent = 3.2;
-    const slowBlend = 0.22;
-    const magnetExponent = 0.68;
+    const slowSpeed = 0.08;
+    const fastSpeed = 1.5;
+    const curveStrength = 6;
+    const pivot = 0.2;
+    // La curva logística suaviza la entrada desde la derecha: las notas avanzan
+    // muy despacio al inicio y aceleran de forma progresiva al aproximarse al
+    // punto de atracción magnética.
 
-    if (normalized <= magnetZone) {
-      const safeZone = Math.max(magnetZone, Number.EPSILON);
-      const magnetT = Math.max(0, Math.min(1, normalized / safeZone));
-      const easedMagnet = Math.pow(magnetT, Math.max(Number.EPSILON, magnetExponent));
-      adjustedNormalized = magnetZone * easedMagnet;
-    } else {
-      const regionT = (normalized - magnetZone) / (1 - magnetZone);
-      const easedSlow =
-        slowBlend * regionT +
-        (1 - slowBlend) * Math.pow(Math.max(0, regionT), slowExponent);
-      adjustedNormalized = magnetZone + (1 - magnetZone) * Math.min(1, easedSlow);
-    }
+    const log1p = Math.log1p || ((value) => Math.log(1 + value));
+    const expArgument = curveStrength * (normalized - pivot);
+    const expAhead = Math.exp(expArgument);
+    const expPivot = Math.exp(-curveStrength * pivot);
+    const expTail = Math.exp(curveStrength * (1 - pivot));
+    const invCurveStrength = 1 / curveStrength;
+    const integralTerm =
+      normalized -
+      invCurveStrength * log1p(expAhead) +
+      invCurveStrength * log1p(expPivot);
+    const normalization =
+      slowSpeed +
+      (fastSpeed - slowSpeed) *
+        (1 -
+          invCurveStrength * log1p(expTail) +
+          invCurveStrength * log1p(expPivot));
+    const curvedNormalized =
+      slowSpeed * normalized + (fastSpeed - slowSpeed) * integralTerm;
+    adjustedNormalized =
+      normalization > 0 ? curvedNormalized / normalization : curvedNormalized;
     adjustedNormalized = Math.max(0, Math.min(1, adjustedNormalized));
   } else {
     const progress = 0.5 + normalized * 0.5;


### PR DESCRIPTION
## Summary
- reemplaza la curva magnética anterior por una logística que desacelera más las notas entrantes y acelera progresivamente al acercarse al punto de atracción
- alinea la prueba de alineación de notas con la nueva fórmula y documenta el comportamiento esperado

## Testing
- node test_note_alignment.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d5c9feeb0833385079b82fc52e835)