### PR TITLE
Simplify advanced panels with floating windows

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,9 +154,10 @@
                 <p class="summary-subtitle">Accesos directos a configuraciones avanzadas.</p>
                 <nav id="bottom-menu">
                   <button
-                    id="open-family-panel"
+                    id="open-family-shortcut"
+                    data-window-target="family-window"
                     title="Ir al panel de familias"
-                    data-help="Abre la pestaña de familias y despliega sus controles detallados."
+                    data-help="Abre la ventana de familias y despliega sus controles detallados."
                   >Familias</button>
                   <button
                     id="tap-tempo-mode-secondary"
@@ -189,115 +190,194 @@
         </div>
 
         <div class="advanced-stage tabbed-card" data-tab-group="advanced-tabs">
-          <div class="tab-header subtle">
-            <button class="tab-trigger active" data-tab-target="familias">Familias</button>
-            <button class="tab-trigger" data-tab-target="tap">Tap tempo</button>
+          <div class="tab-header subtle compact-tabs">
+            <div class="tab-group-label">
+              <span class="tiny-label">Avanzado</span>
+              <strong>Paneles flotantes</strong>
+            </div>
+            <div class="tab-trigger-row">
+              <button class="tab-trigger active" data-tab-target="familias">Familias</button>
+              <button class="tab-trigger" data-tab-target="tap">Tap tempo</button>
+            </div>
           </div>
           <div class="tab-panels">
             <div class="tab-panel active" data-tab-panel="familias">
-              <div class="tab-panel-header">
+              <div class="micro-card">
                 <div>
                   <div class="summary-title">Color y forma</div>
-                  <p class="summary-subtitle">Organiza cada familia sin perder la vista principal.</p>
+                  <p class="summary-subtitle">Personaliza familias en una ventana dedicada.</p>
                 </div>
-                <button
-                  id="toggle-family-panel"
-                  class="ghost-button"
-                  title="Panel de familias"
-                  data-help="Despliega el panel para personalizar color y figura de cada familia."
-                >Panel de familias</button>
+                <div class="chip-row">
+                  <button
+                    id="open-family-panel"
+                    class="chip-button"
+                    data-window-target="family-window"
+                    title="Abrir panel de familias"
+                    data-help="Abre una ventana flotante para ajustar color, forma y asignaciones de cada familia."
+                  >Abrir panel</button>
+                  <button
+                    id="toggle-family-panel"
+                    class="chip-button ghost"
+                    data-window-target="family-window"
+                    data-window-mode="toggle"
+                    title="Mostrar u ocultar el panel"
+                    data-help="Despliega u oculta la ventana de familias sin perder la configuración."
+                  >▼</button>
+                </div>
               </div>
-              <div class="panel-body">
-                <div id="family-config-panel" class="active">
-                  <div id="developer-controls"></div>
+              <div class="micro-grid">
+                <div class="micro-card muted">
+                  <p class="micro-title">Atajos rápidos</p>
+                  <p class="micro-text">Asigna familias desde el modal de instrumentos y conserva tus combinaciones favoritas.</p>
+                </div>
+                <div class="micro-card muted">
+                  <p class="micro-title">Visual compacto</p>
+                  <p class="micro-text">Los controles se agrupan por secciones para evitar desbordes y mantener todo visible.</p>
                 </div>
               </div>
             </div>
 
             <div class="tab-panel" data-tab-panel="tap">
-              <div class="tab-panel-header">
+              <div class="micro-card">
                 <div>
                   <div class="summary-title">Mapa de tempo</div>
-                  <p class="summary-subtitle">Pulsa, edita marcadores y refina la sincronía.</p>
+                  <p class="summary-subtitle">Pulsa y ajusta marcadores sin salir del lienzo.</p>
                 </div>
-                <button
-                  id="tap-tempo-mode-tertiary"
-                  data-action="tap-tempo"
-                  class="ghost-button"
-                  title="Modo tap tempo"
-                  data-help="Alterna rápidamente al panel de tap tempo."
-                >Abrir tap tempo</button>
+                <div class="chip-row">
+                  <button
+                    id="tap-tempo-mode-tertiary"
+                    data-action="tap-tempo"
+                    class="chip-button"
+                    data-window-target="tap-window"
+                    title="Abrir herramientas de tap tempo"
+                    data-help="Activa las herramientas de tap tempo en una ventana flotante."
+                  >Abrir tap tempo</button>
+                  <button
+                    class="chip-button ghost"
+                    data-window-target="tap-window"
+                    data-window-mode="toggle"
+                    title="Mostrar u ocultar la ventana de tap tempo"
+                  >▼</button>
+                </div>
               </div>
-              <div class="panel-body">
-                <div id="tap-tempo-panel" class="hidden">
-                  <div id="tap-tempo-controls">
-                    <button
-                      id="start-tap-tempo"
-                      title="Iniciar captura de tap tempo"
-                      data-help="Reproduce el audio desde el inicio y registra tus pulsos con cualquier tecla."
-                    >Iniciar tap tempo</button>
-                    <button
-                      id="stop-tap-tempo"
-                      title="Detener o reiniciar el proceso de tap tempo"
-                      data-help="Detiene la captura en curso o restaura el mapa de tempo original sin necesidad de volver a cargar el audio."
-                    >Reiniciar proceso tap tempo</button>
-                    <p id="tap-tempo-status">
-                      Carga un archivo WAV y utiliza el tap tempo para crear un mapa de tempo personalizado. Usa Alt+clic para añadir marcadores,
-                      muévelos desde el punto superior con las flechas y elimínalos desde el punto inferior.
-                    </p>
-                  </div>
-                  <div id="tap-tempo-editor" class="hidden">
-                    <div class="tap-tempo-toolbar">
-                      <label>
-                        Zoom
-                        <input
-                          type="range"
-                          id="tap-zoom"
-                          min="0"
-                          max="100"
-                          value="0"
-                          title="Ajusta la cantidad de audio visible en la forma de onda"
-                        />
-                      </label>
-                      <label>
-                        Posición
-                        <input
-                          type="range"
-                          id="tap-position"
-                          min="0"
-                          max="100"
-                          value="0"
-                          title="Desplaza la ventana visible de la forma de onda"
-                        />
-                      </label>
-                      <button
-                        id="tap-marker-add"
-                        type="button"
-                        title="Agregar un nuevo marcador (también disponible con Alt+clic)"
-                      >Agregar marcador</button>
-                      <button
-                        id="tap-marker-delete"
-                        type="button"
-                        title="Eliminar el marcador seleccionado"
-                      >Eliminar marcador</button>
-                    </div>
-                    <canvas
-                      id="tap-waveform"
-                      width="1200"
-                      height="360"
-                      title="Forma de onda del audio con marcadores de tempo"
-                    ></canvas>
-                    <p class="tap-tempo-hint">
-                      Arrastra cada marcador desde el punto superior con las flechas dobles para reubicarlo. Usa Alt+clic en la forma de onda para añadir nuevos marcadores y haz clic en el punto inferior con el signo menos para eliminarlo.
-                    </p>
-                  </div>
-                  <div id="tap-tooltip" class="tooltip hidden"></div>
+              <div class="micro-grid">
+                <div class="micro-card muted">
+                  <p class="micro-title">Modo guiado</p>
+                  <p class="micro-text">Los mensajes de ayuda se alinean al cursor y se mantienen dentro de la ventana.</p>
+                </div>
+                <div class="micro-card muted">
+                  <p class="micro-title">Edición segura</p>
+                  <p class="micro-text">Los marcadores se ordenan automáticamente para evitar solapamientos accidentales.</p>
                 </div>
               </div>
             </div>
           </div>
         </div>
       </section>
+    </div>
+
+    <div id="family-window" class="floating-window hidden">
+      <div class="window-shell">
+        <div class="window-header">
+          <div>
+            <p class="window-eyebrow">Ajustes avanzados</p>
+            <p class="window-title">Panel de familias</p>
+            <p class="window-subtitle">Colores, formas y asignaciones en un espacio separado.</p>
+          </div>
+          <div class="window-actions">
+            <button class="chip-button ghost" data-close-window="family-window" aria-label="Cerrar panel">×</button>
+          </div>
+        </div>
+        <div class="window-body">
+          <div id="family-config-panel">
+            <div id="developer-controls"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div id="tap-window" class="floating-window hidden">
+      <div class="window-shell">
+        <div class="window-header">
+          <div>
+            <p class="window-eyebrow">Sincronía</p>
+            <p class="window-title">Tap tempo y mapa</p>
+            <p class="window-subtitle">Pulsa, corrige marcadores y refina el tempo en un panel limpio.</p>
+          </div>
+          <div class="window-actions">
+            <button class="chip-button ghost" data-close-window="tap-window" aria-label="Cerrar tap tempo">×</button>
+          </div>
+        </div>
+        <div class="window-body">
+          <div class="tap-window-intro">
+            <p>Inicia la captura para ver la forma de onda y manipular los marcadores sin tapar el lienzo principal.</p>
+          </div>
+          <div id="tap-tempo-panel" class="hidden">
+            <div id="tap-tempo-controls">
+              <button
+                id="start-tap-tempo"
+                title="Iniciar captura de tap tempo"
+                data-help="Reproduce el audio desde el inicio y registra tus pulsos con cualquier tecla."
+              >Iniciar tap tempo</button>
+              <button
+                id="stop-tap-tempo"
+                title="Detener o reiniciar el proceso de tap tempo"
+                data-help="Detiene la captura en curso o restaura el mapa de tempo original sin necesidad de volver a cargar el audio."
+              >Reiniciar proceso tap tempo</button>
+              <p id="tap-tempo-status">
+                Carga un archivo WAV y utiliza el tap tempo para crear un mapa de tempo personalizado. Usa Alt+clic para añadir marcadores,
+                muévelos desde el punto superior con las flechas y elimínalos desde el punto inferior.
+              </p>
+            </div>
+            <div id="tap-tempo-editor" class="hidden">
+              <div class="tap-tempo-toolbar">
+                <label>
+                  Zoom
+                  <input
+                    type="range"
+                    id="tap-zoom"
+                    min="0"
+                    max="100"
+                    value="0"
+                    title="Ajusta la cantidad de audio visible en la forma de onda"
+                  />
+                </label>
+                <label>
+                  Posición
+                  <input
+                    type="range"
+                    id="tap-position"
+                    min="0"
+                    max="100"
+                    value="0"
+                    title="Desplaza la ventana visible de la forma de onda"
+                  />
+                </label>
+                <button
+                  id="tap-marker-add"
+                  type="button"
+                  title="Agregar un nuevo marcador (también disponible con Alt+clic)"
+                >Agregar marcador</button>
+                <button
+                  id="tap-marker-delete"
+                  type="button"
+                  title="Eliminar el marcador seleccionado"
+                >Eliminar marcador</button>
+              </div>
+              <canvas
+                id="tap-waveform"
+                width="1200"
+                height="360"
+                title="Forma de onda del audio con marcadores de tempo"
+              ></canvas>
+              <p class="tap-tempo-hint">
+                Arrastra cada marcador desde el punto superior con las flechas dobles para reubicarlo. Usa Alt+clic en la forma de onda para añadir nuevos marcadores y haz clic en el punto inferior con el signo menos para eliminarlo.
+              </p>
+            </div>
+            <div id="tap-tooltip" class="tooltip hidden"></div>
+          </div>
+        </div>
+      </div>
     </div>
 
     <input

--- a/styles.css
+++ b/styles.css
@@ -400,6 +400,96 @@ input:focus-visible {
   margin-top: calc(var(--spacing-unit) * 0.5);
 }
 
+.compact-tabs {
+  align-items: center;
+  justify-content: space-between;
+  gap: calc(var(--spacing-unit) * 0.75);
+}
+
+.tab-group-label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 160px;
+}
+
+.tab-trigger-row {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tiny-label {
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(109, 225, 255, 0.12);
+  border: 1px solid rgba(109, 225, 255, 0.25);
+  text-transform: uppercase;
+  font-size: 0.75em;
+  letter-spacing: 0.08em;
+  width: fit-content;
+}
+
+.micro-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-unit);
+  padding: calc(var(--spacing-unit) * 1.1);
+  border-radius: calc(var(--panel-radius) - 4px);
+  border: 1px solid #252525;
+  background: linear-gradient(140deg, #1a1a1a, #111);
+}
+
+.micro-card.muted {
+  background: linear-gradient(140deg, #151515, #0f0f0f);
+  border-color: #222;
+}
+
+.micro-grid {
+  display: grid;
+  gap: var(--spacing-unit);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.micro-title {
+  margin: 0 0 4px;
+  font-weight: 700;
+}
+
+.micro-text {
+  margin: 0;
+  color: #c8c8c8;
+  line-height: 1.4;
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip-button {
+  padding: 9px 12px;
+  border-radius: 10px;
+  border: 1px solid #2d2d2d;
+  background: linear-gradient(140deg, #1f1f1f, #151515);
+  color: #f2f2f2;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.chip-button.ghost {
+  background: transparent;
+  border-color: #2a2a2a;
+}
+
+.chip-button:hover {
+  border-color: rgba(109, 225, 255, 0.5);
+}
+
 .canvas-header {
   display: flex;
   align-items: center;
@@ -443,7 +533,7 @@ input:focus-visible {
 }
 
 #family-config-panel {
-  display: none;
+  display: grid;
   margin: 0;
   background: #1a1a1a;
   padding: var(--spacing-unit);
@@ -454,12 +544,8 @@ input:focus-visible {
   gap: var(--spacing-unit);
   border-radius: var(--panel-radius);
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
-  max-height: 520px;
+  max-height: 70vh;
   overflow: auto;
-}
-
-#family-config-panel.active {
-  display: grid;
 }
 
 #developer-controls {
@@ -913,6 +999,87 @@ input:focus-visible {
 
 .hidden {
   display: none;
+}
+
+.floating-window {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(6px);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: calc(var(--spacing-unit) * 2);
+  box-sizing: border-box;
+  z-index: 1200;
+}
+
+.floating-window:not(.hidden) {
+  display: flex;
+}
+
+.window-shell {
+  width: min(1220px, 96vw);
+  max-height: 88vh;
+  background: linear-gradient(160deg, #161616, #0f0f0f);
+  border: 1px solid #262626;
+  border-radius: 18px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.window-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-unit);
+  padding: calc(var(--spacing-unit) * 1.25) calc(var(--spacing-unit) * 1.5);
+  border-bottom: 1px solid #242424;
+  background: linear-gradient(160deg, rgba(109, 225, 255, 0.08), rgba(109, 225, 255, 0));
+}
+
+.window-eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75em;
+  opacity: 0.8;
+}
+
+.window-title {
+  margin: 2px 0;
+  font-size: 1.4rem;
+  font-weight: 800;
+}
+
+.window-subtitle {
+  margin: 0;
+  color: #cfcfcf;
+}
+
+.window-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.window-body {
+  padding: calc(var(--spacing-unit) * 1.5);
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-unit);
+}
+
+.tap-window-intro {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid #242424;
+  border-radius: 12px;
+  padding: var(--spacing-unit);
+  line-height: 1.5;
+  color: #e0e0e0;
 }
 
 .tooltip {


### PR DESCRIPTION
## Summary
- replace the advanced tab content with compact launchers for families and tap tempo
- introduce floating window layouts for the family and tap-tempo controls to keep the main view tidy
- refresh styling with chip buttons, micro cards, and modal shells to avoid overflow

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941dde645d88333aac927b6923c501e)